### PR TITLE
Add github action to build and test project on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: macOS
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+    # Checks-out the repo. More at: https://github.com/actions/checkout
+    - uses: actions/checkout@v2
+    - name: Build project
+      run: swift build
+    - name: Run tests
+      run: swift test


### PR DESCRIPTION
This adds [GitHub Actions](https://help.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow) to build and test this project on pushes to the repo

cc @dfed  