### PR TITLE
Ignore Tests from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "Tests/**/*"


### PR DESCRIPTION
Code Cov was reporting code coverage on the tests themselves. Let's remove that.