### PR TITLE
Fixes a bug when subfolder has spaces

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,4 +34,4 @@ To add a new command create a `YourCommand.swift` file inside the `Commands` fol
 
 ### Adding new functionality
 
-Since we want to separate the commands from the core functionality, you should abstract your core functionality in a class that lives in the `Core` folder in `SwiftInspectorKit`.
+Since we want to separate the commands from the core functionality, you should abstract your core functionality in a class that lives in `SwiftInspectorKit`.

--- a/Sources/SwiftInspectorKit/FileManager+SwiftFiles.swift
+++ b/Sources/SwiftInspectorKit/FileManager+SwiftFiles.swift
@@ -40,7 +40,7 @@ extension FileManager {
 
     guard let enumerator = self.enumerator(
       at: baseURL,
-      includingPropertiesForKeys: [.isDirectoryKey],
+      includingPropertiesForKeys: nil,
       options: [.skipsHiddenFiles])
       else
     {

--- a/Sources/SwiftInspectorKit/FileManager+SwiftFiles.swift
+++ b/Sources/SwiftInspectorKit/FileManager+SwiftFiles.swift
@@ -38,10 +38,17 @@ extension FileManager {
 
     var swiftFiles: [URL] = []
 
-    let enumerator = self.enumerator(atPath: baseURL.path)
-    while let path = enumerator?.nextObject() as? String {
-      let fileURL = URL(string: path, relativeTo: baseURL)
-      if let fileURL = fileURL, fileURL.pathExtension == "swift" {
+    guard let enumerator = self.enumerator(
+      at: baseURL,
+      includingPropertiesForKeys: [.isDirectoryKey],
+      options: [.skipsHiddenFiles])
+      else
+    {
+      return  []
+    }
+
+    for case let fileURL as URL in enumerator {
+      if fileURL.pathExtension == "swift" {
         swiftFiles.append(fileURL.standardizedFileURL)
       }
     }

--- a/Tests/SwiftInspectorKitTests/FileManagerSpec.swift
+++ b/Tests/SwiftInspectorKitTests/FileManagerSpec.swift
@@ -102,12 +102,23 @@ final class FileManagerSpec: QuickSpec {
         }
 
         context("when there are swift files in subfolders") {
-          it("it returns the swift file in the subfolder") {
+          it("returns the swift file in the subfolder") {
             let parentURL = try! Temporary.makeFolder()
             let subfolderURL = try! Temporary.makeFolder(parentPath: parentURL.path)
             let fileURL = try! Temporary.makeFile(content: "", atPath: subfolderURL.path)
 
             expect(fileManager.swiftFiles(at: parentURL)) == [fileURL]
+          }
+        }
+
+        context("with a subfolder with spaces")  {
+          it("returns the swift files in the subfolder") {
+            let parentURL = try! Temporary.makeFolder(parentPath: parentURL.path)
+            let subfolderURL = try! Temporary.makeFolder(name: "Some Folder Name", parentPath: parentURL.path)
+            let fileURL = try! Temporary.makeFile(content: "", atPath: subfolderURL.path)
+
+            expect(fileManager.swiftFiles(at: parentURL)) == [fileURL]
+
           }
         }
       }


### PR DESCRIPTION
My current approach to traversing the file structure has a bug, it doesn't work when a subfolder has spaces.

This fixes that bug.