### PR TITLE
Add typealias command

### DIFF
--- a/Sources/SwiftInspectorCommands/Tests/TypealiasCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypealiasCommandSpec.swift
@@ -1,0 +1,85 @@
+// Created by Francisco Diaz on 3/25/20.
+//
+// Copyright (c) 2020 Francisco Diaz
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Nimble
+import Quick
+@testable import SwiftInspectorCore
+
+final class TypealiasCommandSpec: QuickSpec {
+  override func spec() {
+    var fileURL: URL!
+    var path: String!
+
+    beforeEach {
+      fileURL = try? Temporary.makeFile(content: "final class Some: SomeType { }")
+      path = fileURL?.path ?? ""
+    }
+
+    afterEach {
+      try? Temporary.removeItem(at: fileURL)
+    }
+
+    describe("run") {
+      context("with no arguments") {
+        it("fails") {
+          let result = try? TestTask.run(withArguments: ["typealias"])
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("with no --name argument") {
+        it("fails") {
+          let result = try? TestTask.run(withArguments: ["typealias", "--path", path])
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("with an empty --name argument") {
+        it("fails") {
+          let result = try? TestTask.run(withArguments: ["typealias", "--name", "", "--path", path])
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("with all arguments") {
+        context("when path doesn't exist") {
+          it("fails") {
+            let result = try? TestTask.run(withArguments: ["typealias", "--name", "SomeAlias", "--path", "/abc"])
+            expect(result?.didSucceed) == false
+          }
+        }
+
+        context("when path exists") {
+          it("succeeds") {
+            let result = try? TestTask.run(withArguments: ["typealias", "--name", "SomeAlias", "--path", path])
+            expect(result?.didSucceed) == true
+          }
+        }
+
+      }
+
+    }
+  }
+}

--- a/Sources/SwiftInspectorCommands/Tests/TypealiasCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypealiasCommandSpec.swift
@@ -33,7 +33,7 @@ final class TypealiasCommandSpec: QuickSpec {
     var path: String!
 
     beforeEach {
-      fileURL = try? Temporary.makeFile(content: "final class Some: SomeType { }")
+      fileURL = try? Temporary.makeFile(content: "typealias SomeAlias = SomeType")
       path = fileURL?.path ?? ""
     }
 
@@ -50,24 +50,44 @@ final class TypealiasCommandSpec: QuickSpec {
       }
 
       context("with no --name argument") {
-        it("fails") {
-          let result = try? TestTask.run(withArguments: ["typealias", "--path", path])
-          expect(result?.didFail) == true
+        var result: TaskStatus?
+        beforeEach {
+          result = try? TestTask.run(withArguments: ["typealias", "--path", path])
+        }
+
+        it("succeeds") {
+          expect(result?.didSucceed) == true
+        }
+
+        it("outputs the typealias information") {
+          expect(result?.outputMessage).to(contain("SomeAlias"))
+        }
+
+        it("does not output the typelias identifiers") {
+          expect(result?.outputMessage).toNot(contain("SomeType"))
         }
       }
 
       context("with an empty --name argument") {
-        it("fails") {
+        it("succeeds") {
           let result = try? TestTask.run(withArguments: ["typealias", "--name", "", "--path", path])
+          expect(result?.didSucceed) == true
+        }
+      }
+
+      context("with an empty --path argument") {
+        it("fails") {
+          let result = try? TestTask.run(withArguments: ["typealias", "--path", ""])
           expect(result?.didFail) == true
         }
       }
 
       context("with all arguments") {
+
         context("when path doesn't exist") {
           it("fails") {
             let result = try? TestTask.run(withArguments: ["typealias", "--name", "SomeAlias", "--path", "/abc"])
-            expect(result?.didSucceed) == false
+            expect(result?.didFail) == true
           }
         }
 
@@ -76,6 +96,22 @@ final class TypealiasCommandSpec: QuickSpec {
             let result = try? TestTask.run(withArguments: ["typealias", "--name", "SomeAlias", "--path", path])
             expect(result?.didSucceed) == true
           }
+        }
+
+        it("outputs the typealias information") {
+          let result = try? TestTask.run(withArguments: ["typealias", "--name", "SomeAlias", "--path", path])
+          expect(result?.outputMessage).to(contain("SomeAlias"))
+        }
+
+        it("does not output the typealias information if the name is different") {
+          let result = try? TestTask.run(withArguments: ["typealias", "--name", "AnotherTypealias", "--path", path])
+          expect(result?.outputMessage).toNot(contain("SomeAlias"))
+        }
+
+        it("outputs the typealias identifiers") {
+          let result = try? TestTask.run(withArguments: ["typealias", "--name", "SomeAlias", "--path", path])
+          expect(result?.outputMessage).to(contain("SomeAlias"))
+          expect(result?.outputMessage).to(contain("SomeType"))
         }
 
       }

--- a/Sources/SwiftInspectorCommands/Tests/TypealiasCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypealiasCommandSpec.swift
@@ -66,6 +66,20 @@ final class TypealiasCommandSpec: QuickSpec {
         it("does not output the typelias identifiers") {
           expect(result?.outputMessage).toNot(contain("SomeType"))
         }
+
+        context("when a typealias is defined multiple times") {
+          it("only returns one the typealias name once") {
+            fileURL = try? Temporary.makeFile(content: """
+                                                       typealias SomeAlias = SomeType
+                                                       typealias SomeAlias = SomethingElse
+                                                       """
+                                                       )
+            result = try? TestTask.run(withArguments: ["typealias", "--path", fileURL!.path])
+
+            let lines = result?.outputMessage?.split { $0.isNewline }.count
+            expect(lines) == 1
+          }
+        }
       }
 
       context("with an empty --name argument") {
@@ -82,7 +96,7 @@ final class TypealiasCommandSpec: QuickSpec {
         }
       }
 
-      context("with all arguments") {
+      context("with --name and --path") {
 
         context("when path doesn't exist") {
           it("fails") {

--- a/Sources/SwiftInspectorCommands/TypealiasCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypealiasCommand.swift
@@ -1,4 +1,4 @@
-// Created by Francisco Diaz on 3/11/20.
+// Created by Francisco Diaz on 3/25/20.
 //
 // Copyright (c) 2020 Francisco Diaz
 //
@@ -23,17 +23,34 @@
 // SOFTWARE.
 
 import ArgumentParser
+import Foundation
 
-public struct InspectorCommand: ParsableCommand {
-  public init() {}
+final class TypealiasCommand: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "typealias",
+    abstract: "Finds information related to the declaration of a typelias"
+  )
 
-  public static var configuration = CommandConfiguration(
-    commandName: "SwiftInspector",
-    abstract: "A command line tool to help inspect usage of classes, protocols, properties, etc in a Swift codebase.",
-    subcommands: [
-      ImportsCommand.self,
-      StaticUsageCommand.self,
-      TypealiasCommand.self,
-      TypeConformanceCommand.self,
-  ])
+  @Option()
+  var name: String
+
+  @Option()
+  var path: String
+
+  /// Runs the command
+  func run() throws {
+  }
+
+  /// Validates if the arguments of this command are valid
+  func validate() throws {
+    guard !name.isEmpty else {
+      throw InspectorError.emptyArgument(argumentName: "--name")
+    }
+    guard !path.isEmpty else {
+      throw InspectorError.emptyArgument(argumentName: "--path")
+    }
+    guard FileManager.default.fileExists(atPath: path) else {
+      throw InspectorError.invalidArgument(argumentName: "--path", value: path)
+    }
+  }
 }

--- a/Sources/SwiftInspectorCore/Tests/TypealiasAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypealiasAnalyzerSpec.swift
@@ -83,7 +83,8 @@ final class TypealiasAnalyzerSpec: QuickSpec {
           fileURL = try! Temporary.makeFile(
             content: """
                      final class Some {
-                       typealias SomeTypealias = SomeType & SomeOtherType
+                       typealias SomeTypealias = SomeType
+                                                 & SomeOtherType
                      }
 
                      typealias AnotherTypealias = AnotherType

--- a/Sources/SwiftInspectorCore/Tests/TypealiasAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypealiasAnalyzerSpec.swift
@@ -1,0 +1,109 @@
+// Created by Francisco Diaz on 3/25/20.
+//
+// Copyright (c) 2020 Francisco Diaz
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Nimble
+import Quick
+import Foundation
+
+@testable import SwiftInspectorCore
+
+final class TypealiasAnalyzerSpec: QuickSpec {
+  override func spec() {
+    var fileURL: URL!
+    var sut = TypealiasAnalyzer()
+
+    beforeEach {
+      sut = TypealiasAnalyzer()
+    }
+
+    afterEach {
+      guard let fileURL = fileURL else {
+        return
+      }
+      try? Temporary.removeItem(at: fileURL)
+    }
+
+    describe("analyze(fileURL:)") {
+      context("when there is no typealias statement") {
+        it("returns an empty array") {
+          fileURL = try! Temporary.makeFile(
+            content: """
+                     final class SomeClass {}
+                     """
+          )
+
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result).to(beEmpty())
+        }
+      }
+
+      context("with a single typealias statement") {
+        beforeEach {
+          fileURL = try! Temporary.makeFile(
+            content: """
+                     typealias SomeTypealias = TypeA & TypeB
+                     """
+          )
+        }
+
+        it("returns the name of the typelias") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.first?.name) == "SomeTypealias"
+        }
+
+        it("returns the identifiers") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.first?.identifiers) == ["TypeA", "TypeB"]
+        }
+      }
+
+      context("with multiple typealias statements") {
+        beforeEach {
+          fileURL = try! Temporary.makeFile(
+            content: """
+                     final class Some {
+                       typealias SomeTypealias = SomeType & SomeOtherType
+                     }
+
+                     typealias AnotherTypealias = AnotherType
+                     """
+          )
+        }
+
+        it("returns all the names of the typeliases") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.first?.name) == "SomeTypealias"
+          expect(result?.last?.name) == "AnotherTypealias"
+        }
+
+        it("returns the identifiers") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.first?.identifiers) == ["SomeType", "SomeOtherType"]
+          expect(result?.last?.identifiers) == ["AnotherType"]
+        }
+      }
+
+    }
+  }
+}

--- a/Sources/SwiftInspectorCore/TypealiasAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypealiasAnalyzer.swift
@@ -1,0 +1,93 @@
+// Created by Francisco Diaz on 3/25/20.
+//
+// Copyright (c) 2020 Francisco Diaz
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import SwiftSyntax
+
+public final class TypealiasAnalyzer: Analyzer {
+
+  /// - Parameter cachedSyntaxTree: The cached syntax tree to return the AST tree from
+  public init(cachedSyntaxTree: CachedSyntaxTree = .init()) {
+    self.cachedSyntaxTree = cachedSyntaxTree
+  }
+
+  /// Analyzes the imports of the Swift file
+  /// - Parameter fileURL: The fileURL where the Swift file is located
+  public func analyze(fileURL: URL) throws -> [TypealiasStatement] {
+    let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
+    var allTypealias: [TypealiasStatement] = []
+    let reader = TypealiasSyntaxReader() { [unowned self] node in
+      let statement = self.typealiasStatement(from: node)
+      allTypealias.append(statement)
+    }
+    _ = reader.visit(syntax)
+
+    return allTypealias
+  }
+
+  // MARK: Private
+  private let cachedSyntaxTree: CachedSyntaxTree
+
+  private func typealiasStatement(from node: TypealiasDeclSyntax) -> TypealiasStatement {
+    var identifiers: [String] = []
+
+    for child in node.children {
+      guard let typeInitializerSyntax = child as? TypeInitializerClauseSyntax else {
+        continue
+      }
+
+      identifiers = findIdentifiers(from: typeInitializerSyntax)
+    }
+
+    return TypealiasStatement(name: node.identifier.text, identifiers:identifiers)
+  }
+
+  private func findIdentifiers(from node: TypeInitializerClauseSyntax) -> [String] {
+    return node.tokens.reduce(into: []) { result, token in
+      switch token.tokenKind {
+      case .identifier(let name): result.append(name)
+      default: return
+      }
+    }
+  }
+}
+
+// TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
+private final class TypealiasSyntaxReader: SyntaxRewriter {
+  init(onNodeVisit: @escaping (TypealiasDeclSyntax) -> Void) {
+    self.onNodeVisit = onNodeVisit
+  }
+
+  override func visit(_ node: TypealiasDeclSyntax) -> DeclSyntax {
+    onNodeVisit(node)
+    return super.visit(node)
+  }
+
+  let onNodeVisit: (TypealiasDeclSyntax) -> Void
+}
+
+public struct TypealiasStatement: Hashable {
+  public let name: String
+  public var identifiers: [String]
+}


### PR DESCRIPTION
**This PR is easier to review commit-by-commit**

This adds a new `typealias` command that:
- Finds all the typealias declarations in a file or folder and outputs all the names
- Has an optional `--name`  parameter to filter for a single typealias and also outputs information related to the identifiers of the typealias