### PR TITLE
Add tests for multiple typealias with the same name

### DIFF
--- a/Sources/SwiftInspectorCommands/Tests/TypealiasCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypealiasCommandSpec.swift
@@ -73,7 +73,7 @@ final class TypealiasCommandSpec: QuickSpec {
                                                        typealias SomeAlias = SomeType
                                                        typealias SomeAlias = SomethingElse
                                                        """
-                                                       )
+            )
             result = try? TestTask.run(withArguments: ["typealias", "--path", fileURL!.path])
 
             let lines = result?.outputMessage?.split { $0.isNewline }.count
@@ -128,6 +128,47 @@ final class TypealiasCommandSpec: QuickSpec {
           expect(result?.outputMessage).to(contain("SomeType"))
         }
 
+        context("with a file that has two typealias with the same name and identifiers") {
+          it("returns the typealias information once") {
+            let fileURL = try! Temporary.makeFile(
+              content: """
+                       typealias Foo = Bar
+
+                       struct MyNamespace {
+
+                         typealias Foo = Bar
+
+                       }
+                       """
+            )
+            let result = try? TestTask.run(withArguments: ["typealias", "--name", "Foo", "--path", fileURL.path])
+
+            let lines = result?.outputMessage?.split { $0.isNewline }
+
+            expect(lines?.count) == 1
+          }
+        }
+
+        context("with a file that has two typealias with the same name and different identifiers") {
+          it("returns the typealias information twice") {
+            let fileURL = try! Temporary.makeFile(
+              content: """
+                       typealias Foo = Bar1
+
+                       struct MyNamespace {
+
+                         typealias Foo = Bar2
+
+                       }
+                       """
+            )
+            let result = try? TestTask.run(withArguments: ["typealias", "--name", "Foo", "--path", fileURL.path])
+
+            let lines = result?.outputMessage?.split { $0.isNewline }
+
+            expect(lines?.count) == 2
+          }
+        }
       }
 
     }

--- a/Sources/SwiftInspectorCore/Tests/TypealiasAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypealiasAnalyzerSpec.swift
@@ -105,6 +105,36 @@ final class TypealiasAnalyzerSpec: QuickSpec {
         }
       }
 
+      context("with multiple typealias with the same name") {
+        beforeEach {
+          fileURL = try! Temporary.makeFile(
+            content: """
+                     typealias Foo = Bar
+
+                     struct MyNamespace {
+
+                       typealias Foo = Bar
+
+                     }
+                     """
+          )
+        }
+        
+        it("returns all the names of the typeliases") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.count) == 2
+          expect(result?.first?.name) == "Foo"
+          expect(result?.last?.name) == "Foo"
+        }
+
+        it("returns all the typealias identifiers") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.count) == 2
+          expect(result?.first?.identifiers) == ["Bar"]
+          expect(result?.last?.identifiers) == ["Bar"]
+        }
+      }
+
     }
   }
 }


### PR DESCRIPTION
Add tests to cover for the cases @bachand pointed out here https://github.com/fdiaz/SwiftInspector/pull/10#discussion_r399408837