### PR TITLE
Add type location command

### DIFF
--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -83,18 +83,18 @@ final class TypeLocationCommandSpec: QuickSpec {
               expect(result?.didFail) == true
             }
           }
-        }
 
-        context("when path is a directory") {
-          beforeEach { pathURL = try? Temporary.makeFolder() }
+          context("path is a directory") {
+            beforeEach { pathURL = try? Temporary.makeFolder() }
 
-          it("fails") {
-            let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
-            expect(result?.didFail) == true
+            it("fails") {
+              let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
+              expect(result?.didFail) == true
+            }
           }
         }
 
-        context("when path is a file") {
+        context("all arguments are valid") {
           beforeEach { pathURL = try? Temporary.makeFile(content: "struct Foo { }") }
 
           it("succeeds") {

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -111,7 +111,7 @@ final class TypeLocationCommandSpec: QuickSpec {
               pathURL = try? Temporary.makeFile(content: contents)
 
               let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
-              expect(result?.outputMessage) == "2 2"
+              expect(result?.outputMessage).to(contain("2 2"))
             }
           }
 

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -130,6 +130,29 @@ final class TypeLocationCommandSpec: QuickSpec {
               expect(result?.outputMessage).to(equal("\n"))
             }
           }
+
+          context("multiple types found") {
+            it("outputs line numbers for each type") {
+              let contents =
+              """
+              import Foundation
+
+              struct Foo { }
+
+              public final class Bar {
+                enum Foo { }
+              }
+              """
+
+              pathURL = try? Temporary.makeFile(content: contents)
+
+              let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
+              let lines = result?.outputMessage?.split { $0.isNewline }
+              expect(lines?.count) == 2
+              expect(lines?.first).to(equal("2 2"))
+              expect(lines?.last).to(equal("5 5"))
+            }
+          }
         }
       }
     }

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -158,18 +158,6 @@ final class TypeLocationCommandSpec: QuickSpec {
           }
         }
       }
-
-      describe("outputString") {
-
-        it("shows index of start and end line") {
-          let sut = TypeLocationCommand()
-          let locatedType = LocatedType(
-            name: "MyType",
-            indexOfStartingLine: 10,
-            indexOfEndingLine: 12)
-          expect(sut.outputString(from: locatedType)) == "10 12"
-        }
-      }
     }
   }
 }

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -99,18 +99,36 @@ final class TypeLocationCommandSpec: QuickSpec {
             expect(result?.didSucceed) == true
           }
 
-          it("outputs the correct line numbers") {
-            let contents =
-            """
-            import Foundation
+          context("type is found") {
+            it("outputs the correct line numbers") {
+              let contents =
+              """
+              import Foundation
 
-            struct Foo { }
-            """
+              struct Foo { }
+              """
 
-            pathURL = try? Temporary.makeFile(content: contents)
+              pathURL = try? Temporary.makeFile(content: contents)
 
-            let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
-            expect(result?.outputMessage) == "2 2"
+              let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
+              expect(result?.outputMessage) == "2 2"
+            }
+          }
+
+          context("type is not found") {
+            it("outputs nothing") {
+              let contents =
+              """
+              import Foundation
+
+              struct Foo { }
+              """
+
+              pathURL = try? Temporary.makeFile(content: contents)
+
+              let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Bar")
+              expect(result?.outputMessage).to(equal("\n"))
+            }
           }
         }
       }

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -158,18 +158,16 @@ final class TypeLocationCommandSpec: QuickSpec {
           }
         }
       }
-    }
-
-    describe("LocatedType") {
 
       describe("outputString") {
 
         it("shows index of start and end line") {
+          let sut = TypeLocationCommand()
           let locatedType = LocatedType(
             name: "MyType",
             indexOfStartingLine: 10,
             indexOfEndingLine: 12)
-          expect(locatedType.outputString()) == "10 12"
+          expect(sut.outputString(from: locatedType)) == "10 12"
         }
       }
     }

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -130,7 +130,7 @@ final class TypeLocationCommandSpec: QuickSpec {
               pathURL = try? Temporary.makeFile(content: contents)
 
               let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Bar")
-              expect(result?.outputMessage).to(equal("\n"))
+              expect(result?.outputMessage).to(equal(""))
             }
           }
 

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -35,6 +35,12 @@ final class TypeLocationCommandSpec: QuickSpec {
     var pathURL: URL!
 
     describe("TypeLocationCommand") {
+      afterEach {
+        guard let pathURL = pathURL else {
+          return
+        }
+        try? Temporary.removeItem(at: pathURL)
+      }
 
       describe("run") {
 
@@ -47,7 +53,6 @@ final class TypeLocationCommandSpec: QuickSpec {
 
         context("path is valid") {
           beforeEach { pathURL = try? Temporary.makeFile(content: "struct Foo { }") }
-          afterEach { try? Temporary.removeItem(at: pathURL) }
 
           context("with no --name argument") {
             it("fails") {
@@ -82,7 +87,6 @@ final class TypeLocationCommandSpec: QuickSpec {
 
         context("when path is a directory") {
           beforeEach { pathURL = try? Temporary.makeFolder() }
-          afterEach { try? Temporary.removeItem(at: pathURL) }
 
           it("fails") {
             let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
@@ -92,7 +96,6 @@ final class TypeLocationCommandSpec: QuickSpec {
 
         context("when path is a file") {
           beforeEach { pathURL = try? Temporary.makeFile(content: "struct Foo { }") }
-          afterEach { try? Temporary.removeItem(at: pathURL) }
 
           it("succeeds") {
             let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -130,7 +130,7 @@ final class TypeLocationCommandSpec: QuickSpec {
               pathURL = try? Temporary.makeFile(content: contents)
 
               let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Bar")
-              expect(result?.outputMessage).to(equal(""))
+              expect(result?.outputMessage).to(beEmpty())
             }
           }
 

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -95,6 +95,20 @@ final class TypeLocationCommandSpec: QuickSpec {
           let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
           expect(result?.didSucceed) == true
         }
+
+        it("outputs the correct line numbers") {
+          let contents =
+          """
+          import Foundation
+
+          struct Foo { }
+          """
+
+          pathURL = try? Temporary.makeFile(content: contents)
+
+          let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
+          expect(result?.outputMessage) == "2 2"
+        }
       }
     }
   }

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -1,0 +1,113 @@
+// Created by Michael Bachand on 3/28/20.
+//
+// Copyright (c) 2020 Francisco Diaz
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Nimble
+import Quick
+import Foundation
+
+@testable import SwiftInspectorCore
+
+final class TypeLocationCommandSpec: QuickSpec {
+
+  override func spec() {
+    var pathURL: URL!
+
+    describe("run") {
+
+      context("with no arguments") {
+        it("fails") {
+          let result = try? TestTypeLocationTask.run(path: nil, name: nil)
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("path is valid") {
+        beforeEach { pathURL = try? Temporary.makeFile(content: "struct Foo { }") }
+        afterEach { try? Temporary.removeItem(at: pathURL) }
+
+        context("with no --name argument") {
+          it("fails") {
+            let result = try? TestTypeLocationTask.run(path: pathURL.path, name: nil)
+            expect(result?.didFail) == true
+          }
+        }
+
+        context("with an empty --name argument") {
+          it("fails") {
+            let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "")
+            expect(result?.didFail) == true
+          }
+        }
+      }
+
+      context("name is valid") {
+        context("with no --path argument") {
+          it("fails") {
+            let result = try? TestTypeLocationTask.run(path: nil, name: "Foo")
+            expect(result?.didFail) == true
+          }
+        }
+
+        context("with an empty --path argument") {
+          it("fails") {
+            let result = try? TestTypeLocationTask.run(path: "", name: "Foo")
+            expect(result?.didFail) == true
+          }
+        }
+      }
+
+      context("when path is a directory") {
+        beforeEach { pathURL = try? Temporary.makeFolder() }
+        afterEach { try? Temporary.removeItem(at: pathURL) }
+
+        it("fails") {
+          let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("when path is a file") {
+        beforeEach { pathURL = try? Temporary.makeFile(content: "struct Foo { }") }
+        afterEach { try? Temporary.removeItem(at: pathURL) }
+
+        it("succeeds") {
+          let result = try? TestTypeLocationTask.run(path: pathURL.path, name: "Foo")
+          expect(result?.didSucceed) == true
+        }
+      }
+    }
+  }
+}
+
+private struct TestTypeLocationTask {
+  /// - Parameters:
+  ///   - path: The path with which to execute the task. The `--path` argument is not passed to the task if `nil`.
+  ///   - name: The name with which to execute the task. The `--name` argument is not passed to task if `nil`.
+  fileprivate static func run(path: String?, name: String?) throws -> TaskStatus {
+    var arguments = ["type-location"]
+    name.map { arguments += ["--name", $0] }
+    path.map { arguments += ["--path", $0] }
+    return try TestTask.run(withArguments: arguments)
+  }
+}

--- a/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeLocationCommandSpec.swift
@@ -134,13 +134,16 @@ final class TypeLocationCommandSpec: QuickSpec {
       }
     }
 
-    describe("TypeLocation") {
+    describe("LocatedType") {
 
       describe("outputString") {
 
         it("shows index of start and end line") {
-          let typeLocation = TypeLocation(indexOfStartingLine: 10, indexOfEndingLine: 12)
-          expect(typeLocation.outputString()) == "10 12"
+          let locatedType = LocatedType(
+            name: "MyType",
+            indexOfStartingLine: 10,
+            indexOfEndingLine: 12)
+          expect(locatedType.outputString()) == "10 12"
         }
       }
     }

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -1,4 +1,4 @@
-// Created by Francisco Diaz on 3/11/20.
+// Created by Michael Bachand on 3/28/20.
 //
 // Copyright (c) 2020 Francisco Diaz
 //
@@ -23,19 +23,39 @@
 // SOFTWARE.
 
 import ArgumentParser
+import Foundation
+import SwiftInspectorCore
 
-public struct InspectorCommand: ParsableCommand {
-  public init() {}
+final class TypeLocationCommand: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "type-location",
+    abstract: "Finds the location of a type"
+  )
 
-  public static var configuration = CommandConfiguration(
-    commandName: "SwiftInspector",
-    abstract: "A command line tool to help inspect usage of classes, protocols, properties, etc in a Swift codebase.",
-    subcommands: [
-      ImportsCommand.self,
-      InitializerCommand.self,
-      StaticUsageCommand.self,
-      TypealiasCommand.self,
-      TypeConformanceCommand.self,
-      TypeLocationCommand.self,
-  ])
+  @Option(help: "The name of the type to find the location of")
+  var name: String
+
+  @Option(help: "The absolute path to the file to inspect")
+  var path: String
+
+  /// Runs the command
+  func run() throws {
+    let cachedSyntaxTree = CachedSyntaxTree()
+    _ = cachedSyntaxTree
+    print("Hello, world")
+  }
+
+    /// Validates if the arguments of this command are valid
+  func validate() throws {
+    guard !name.isEmpty else {
+      throw InspectorError.emptyArgument(argumentName: "--name")
+    }
+    guard !path.isEmpty else {
+      throw InspectorError.emptyArgument(argumentName: "--path")
+    }
+    var isDir: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && !isDir.boolValue else {
+      throw InspectorError.invalidArgument(argumentName: "--path", value: path)
+    }
+  }
 }

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -64,7 +64,7 @@ final class TypeLocationCommand: ParsableCommand {
   }
 }
 
-extension TypeLocation {
+extension LocatedType {
 
   func outputString() -> String {
     return "\(indexOfStartingLine) \(indexOfEndingLine)"

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -47,7 +47,7 @@ final class TypeLocationCommand: ParsableCommand {
     let typeLocations = try analyzer.analyze(fileURL: fileURL)
 
     if !typeLocations.isEmpty {
-      print(typeLocations.map { $0.outputString() }.joined(separator: "\n"))
+      print(typeLocations.map { outputString(from: $0) }.joined(separator: "\n"))
     }
   }
 
@@ -64,12 +64,9 @@ final class TypeLocationCommand: ParsableCommand {
       throw InspectorError.invalidArgument(argumentName: "--path", value: path)
     }
   }
-}
 
-extension LocatedType {
-
-  func outputString() -> String {
-    return "\(indexOfStartingLine) \(indexOfEndingLine)"
+  func outputString(from statement: LocatedType) -> String {
+    "\(statement.indexOfStartingLine) \(statement.indexOfEndingLine)"
   }
 }
 

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -32,7 +32,7 @@ final class TypeLocationCommand: ParsableCommand {
     abstract: "Finds the location of a type"
   )
 
-  @Option(help: "The name of the type to find the location of")
+  @Option(help: nameArgumentHelp)
   var name: String
 
   @Option(help: "The absolute path to the file to inspect")
@@ -70,3 +70,9 @@ extension TypeLocation {
     return "\(indexOfStartingLine) \(indexOfEndingLine)"
   }
 }
+
+// We recognize that a protocol may not strictly be a type, but we're OK with cutting that corner
+// for now...
+private let nameArgumentHelp = ArgumentHelp(
+  "The name of the type to find the location of",
+  discussion: "This may be a enum, class, struct, or protocol.")

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -46,7 +46,9 @@ final class TypeLocationCommand: ParsableCommand {
     let fileURL = URL(fileURLWithPath: path)
     let typeLocations = try analyzer.analyze(fileURL: fileURL)
 
-    print(typeLocations.map { $0.outputString() }.joined(separator: "\n"))
+    if !typeLocations.isEmpty {
+      print(typeLocations.map { $0.outputString() }.joined(separator: "\n"))
+    }
   }
 
   /// Validates if the arguments of this command are valid

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -45,7 +45,7 @@ final class TypeLocationCommand: ParsableCommand {
     print("Hello, world")
   }
 
-    /// Validates if the arguments of this command are valid
+  /// Validates if the arguments of this command are valid
   func validate() throws {
     guard !name.isEmpty else {
       throw InspectorError.emptyArgument(argumentName: "--name")
@@ -57,5 +57,12 @@ final class TypeLocationCommand: ParsableCommand {
     guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && !isDir.boolValue else {
       throw InspectorError.invalidArgument(argumentName: "--path", value: path)
     }
+  }
+}
+
+extension TypeLocation {
+
+  func outputString() -> String {
+    return "\(indexOfStartingLine) \(indexOfEndingLine)"
   }
 }

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -70,8 +70,6 @@ final class TypeLocationCommand: ParsableCommand {
   }
 }
 
-// We recognize that a protocol may not strictly be a type, but we're OK with cutting that corner
-// for now...
 private let nameArgumentHelp = ArgumentHelp(
   "The name of the type to find the location of",
   discussion: "This may be a enum, class, struct, or protocol.")

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -35,7 +35,7 @@ final class TypeLocationCommand: ParsableCommand {
   @Option(help: nameArgumentHelp)
   var name: String
 
-  @Option(help: "The absolute path to the file to inspect")
+  @Option(help: "The absolute path of the file to inspect")
   var path: String
 
   /// Runs the command

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -29,7 +29,7 @@ import SwiftInspectorCore
 final class TypeLocationCommand: ParsableCommand {
   static var configuration = CommandConfiguration(
     commandName: "type-location",
-    abstract: "Finds the location of a type"
+    abstract: "Finds the line numbers on which a type is declared"
   )
 
   @Option(help: nameArgumentHelp)

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -59,8 +59,8 @@ final class TypeLocationCommand: ParsableCommand {
     guard !path.isEmpty else {
       throw InspectorError.emptyArgument(argumentName: "--path")
     }
-    var isDir: ObjCBool = false
-    guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir) && !isDir.boolValue else {
+    let pathURL = URL(fileURLWithPath: path)
+    guard FileManager.default.isSwiftFile(at: pathURL) else {
       throw InspectorError.invalidArgument(argumentName: "--path", value: path)
     }
   }

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -65,7 +65,7 @@ final class TypeLocationCommand: ParsableCommand {
     }
   }
 
-  func outputString(from statement: LocatedType) -> String {
+  private func outputString(from statement: LocatedType) -> String {
     "\(statement.indexOfStartingLine) \(statement.indexOfEndingLine)"
   }
 }

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -44,9 +44,9 @@ final class TypeLocationCommand: ParsableCommand {
 
     let analyzer = TypeLocationAnalyzer(typeName: name, cachedSyntaxTree: cachedSyntaxTree)
     let fileURL = URL(fileURLWithPath: path)
-    let typeLocation = try analyzer.analyze(fileURL: fileURL)
+    let typeLocations = try analyzer.analyze(fileURL: fileURL)
 
-    print(typeLocation?.outputString() ?? "")
+    print(typeLocations.map { $0.outputString() }.joined(separator: "\n"))
   }
 
   /// Validates if the arguments of this command are valid

--- a/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
@@ -41,8 +41,12 @@ final class TypeLocationCommand: ParsableCommand {
   /// Runs the command
   func run() throws {
     let cachedSyntaxTree = CachedSyntaxTree()
-    _ = cachedSyntaxTree
-    print("Hello, world")
+
+    let analyzer = TypeLocationAnalyzer(typeName: name, cachedSyntaxTree: cachedSyntaxTree)
+    let fileURL = URL(fileURLWithPath: path)
+    let typeLocation = try analyzer.analyze(fileURL: fileURL)
+
+    print(typeLocation?.outputString() ?? "")
   }
 
   /// Validates if the arguments of this command are valid

--- a/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
@@ -158,24 +158,6 @@ final class InitializerAnalyzerSpec: QuickSpec {
           }
         }
 
-        context("with a closure") {
-          beforeEach {
-            let content = """
-            public final class FakeType {
-              init(someTyple: (String, Int)) {}
-            }
-            """
-            fileURL = try? Temporary.makeFile(content: content)
-          }
-
-          it("returns all the types in the array") {
-            let result = try? sut.analyze(fileURL: fileURL)
-            expect(result?.first?.parameters) == [
-              InitializerStatement.Parameter(name: "someTyple", typeNames: ["String", "Int"]),
-            ]
-          }
-        }
-
         context("with an argument label different than the parameter name") {
           beforeEach {
             let content = """

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -199,44 +199,44 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
       context("type spans multiple lines") {
         context("starting on the first line of the file") {
-           beforeEach {
-             let content =
-             """
+          beforeEach {
+            let content =
+            """
              struct Foo {
                let myProperty: String
              }
              """
-             fileURL = try? Temporary.makeFile(content: content)
-           }
+            fileURL = try? Temporary.makeFile(content: content)
+          }
 
-           it("returns correct start and end indices") {
-             let sut = TypeLocationAnalyzer(typeName: "Foo")
+          it("returns correct start and end indices") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
             let result = try? sut.analyze(fileURL: fileURL).first
-             expect(result?.indexOfStartingLine) == 0
-             expect(result?.indexOfEndingLine) == 2
-           }
-         }
+            expect(result?.indexOfStartingLine) == 0
+            expect(result?.indexOfEndingLine) == 2
+          }
+        }
 
-         context("starting on a line of the file that is not the first") {
-           beforeEach {
-             let content =
-             """
+        context("starting on a line of the file that is not the first") {
+          beforeEach {
+            let content =
+            """
              import Foundation
 
              struct Foo {
                let myProperty: String
              }
              """
-             fileURL = try? Temporary.makeFile(content: content)
-           }
+            fileURL = try? Temporary.makeFile(content: content)
+          }
 
-           it("returns correct start and end indices") {
-             let sut = TypeLocationAnalyzer(typeName: "Foo")
+          it("returns correct start and end indices") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
             let result = try? sut.analyze(fileURL: fileURL).first
-             expect(result?.indexOfStartingLine) == 2
-             expect(result?.indexOfEndingLine) == 4
-           }
-         }
+            expect(result?.indexOfStartingLine) == 2
+            expect(result?.indexOfEndingLine) == 4
+          }
+        }
 
         context("contains another single line type") {
           beforeEach {

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -20,11 +20,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import Foundation
 import Nimble
 import Quick
 
 @testable import SwiftInspectorCore
 
 final class TypeLocationAnalyzerSpec: QuickSpec {
+  private var fileURL: URL!
 
+  override func spec() {
+    afterEach {
+      guard let fileURL = self.fileURL else {
+        return
+      }
+      try? Temporary.removeItem(at: fileURL)
+    }
+  }
 }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -286,6 +286,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           }
         }
       }
+
       context("when multiple types with the same name exist") {
         beforeEach {
           let content =
@@ -307,6 +308,25 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           expect(result?.first?.indexOfEndingLine) == 0
           expect(result?.last?.indexOfStartingLine) == 3
           expect(result?.last?.indexOfEndingLine) == 3
+        }
+      }
+
+      context("when the type has a modifier") {
+        beforeEach {
+          let content =
+          """
+
+          final class Foo {
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        fit("returns correct start and end indices") {
+          let sut = TypeLocationAnalyzer(typeName: "Foo")
+          let result = try? sut.analyze(fileURL: fileURL).first
+          expect(result?.indexOfStartingLine) == 1
+          expect(result?.indexOfEndingLine) == 2
         }
       }
     }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -20,4 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import Foundation
+import Nimble
+import Quick
+
+@testable import SwiftInspectorCore
+
+final class TypeLocationAnalyzerSpec: QuickSpec {
+
+}

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -195,94 +195,94 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
             expect(result?.indexOfEndingLine) == 2
           }
         }
+      }
 
-        context("type spans multiple lines") {
-          context("starting on the first line of the file") {
-             beforeEach {
-               let content =
-               """
-               struct Foo {
-                 let myProperty: String
-               }
-               """
-               fileURL = try? Temporary.makeFile(content: content)
+      context("type spans multiple lines") {
+        context("starting on the first line of the file") {
+           beforeEach {
+             let content =
+             """
+             struct Foo {
+               let myProperty: String
              }
-
-             it("returns correct start and end indices") {
-               let sut = TypeLocationAnalyzer(typeName: "Foo")
-               let result = try? sut.analyze(fileURL: fileURL)
-               expect(result?.indexOfStartingLine) == 0
-               expect(result?.indexOfEndingLine) == 2
-             }
+             """
+             fileURL = try? Temporary.makeFile(content: content)
            }
 
-           context("starting on a line of the file that is not the first") {
-             beforeEach {
-               let content =
-               """
-               import Foundation
+           it("returns correct start and end indices") {
+             let sut = TypeLocationAnalyzer(typeName: "Foo")
+             let result = try? sut.analyze(fileURL: fileURL)
+             expect(result?.indexOfStartingLine) == 0
+             expect(result?.indexOfEndingLine) == 2
+           }
+         }
 
-               struct Foo {
-                 let myProperty: String
-               }
-               """
-               fileURL = try? Temporary.makeFile(content: content)
-             }
+         context("starting on a line of the file that is not the first") {
+           beforeEach {
+             let content =
+             """
+             import Foundation
 
-             it("returns correct start and end indices") {
-               let sut = TypeLocationAnalyzer(typeName: "Foo")
-               let result = try? sut.analyze(fileURL: fileURL)
-               expect(result?.indexOfStartingLine) == 2
-               expect(result?.indexOfEndingLine) == 4
+             struct Foo {
+               let myProperty: String
              }
+             """
+             fileURL = try? Temporary.makeFile(content: content)
            }
 
-          context("contains another single line type") {
-            beforeEach {
-              let content =
-              """
-              import Foundation
+           it("returns correct start and end indices") {
+             let sut = TypeLocationAnalyzer(typeName: "Foo")
+             let result = try? sut.analyze(fileURL: fileURL)
+             expect(result?.indexOfStartingLine) == 2
+             expect(result?.indexOfEndingLine) == 4
+           }
+         }
 
-              struct Foo {
-                let myProperty: String
+        context("contains another single line type") {
+          beforeEach {
+            let content =
+            """
+            import Foundation
 
-                enum Bar { }
-              }
-              """
-              fileURL = try? Temporary.makeFile(content: content)
+            struct Foo {
+              let myProperty: String
+
+              enum Bar { }
             }
-
-            it("returns correct start and end indices") {
-              let sut = TypeLocationAnalyzer(typeName: "Foo")
-              let result = try? sut.analyze(fileURL: fileURL)
-              expect(result?.indexOfStartingLine) == 2
-              expect(result?.indexOfEndingLine) == 6
-            }
+            """
+            fileURL = try? Temporary.makeFile(content: content)
           }
 
-          context("contains another type that spans multiple lines") {
-            beforeEach {
-              let content =
-              """
-              import Foundation
+          it("returns correct start and end indices") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result?.indexOfStartingLine) == 2
+            expect(result?.indexOfEndingLine) == 6
+          }
+        }
 
-              struct Foo {
-                let myProperty: String
+        context("contains another type that spans multiple lines") {
+          beforeEach {
+            let content =
+            """
+            import Foundation
 
-                enum Bar {
-                  case myCase
-                }
+            struct Foo {
+              let myProperty: String
+
+              enum Bar {
+                case myCase
               }
-              """
-              fileURL = try? Temporary.makeFile(content: content)
             }
+            """
+            fileURL = try? Temporary.makeFile(content: content)
+          }
 
-            it("returns correct start and end indices") {
-              let sut = TypeLocationAnalyzer(typeName: "Foo")
-              let result = try? sut.analyze(fileURL: fileURL)
-              expect(result?.indexOfStartingLine) == 2
-              expect(result?.indexOfEndingLine) == 8
-            }
+          it("returns correct start and end indices") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result?.indexOfStartingLine) == 2
+            expect(result?.indexOfEndingLine) == 8
           }
         }
       }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -55,11 +55,13 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
       }
 
       context("struct is present") {
-        let content =
-        """
-        struct Foo { }
-        """
-        fileURL = try? Temporary.makeFile(content: content)
+        beforeEach {
+          let content =
+          """
+          struct Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
 
         it("returns type location") {
           let sut = TypeLocationAnalyzer(typeName: "Foo")
@@ -70,11 +72,14 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
       }
 
       context("enum is present") {
-        let content =
-        """
-        enum Foo { }
-        """
-        fileURL = try? Temporary.makeFile(content: content)
+        beforeEach {
+          let content =
+          """
+          enum Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+
+        }
 
         it("returns type location") {
           let sut = TypeLocationAnalyzer(typeName: "Foo")
@@ -85,11 +90,13 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
       }
 
       context("class is present") {
-        let content =
-        """
-        class Foo { }
-        """
-        fileURL = try? Temporary.makeFile(content: content)
+        beforeEach {
+          let content =
+          """
+          class Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
 
         it("returns type location") {
           let sut = TypeLocationAnalyzer(typeName: "Foo")

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -48,7 +48,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
         it("returns nil") {
           let sut = TypeLocationAnalyzer(typeName: "Foo")
-          let result = try? sut.analyze(fileURL: fileURL)
+          let result = try? sut.analyze(fileURL: fileURL).first
 
           expect(result).to(beNil())
         }
@@ -74,7 +74,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
         context("name does not match") {
           it("returns nil") {
             let sut = TypeLocationAnalyzer(typeName: "Bar")
-            let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
             expect(result).to(beNil())
           }
         }
@@ -101,7 +101,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
         context("name does not match") {
           it("returns nil") {
             let sut = TypeLocationAnalyzer(typeName: "Bar")
-            let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
             expect(result).to(beNil())
           }
         }
@@ -119,7 +119,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
         context("name matches") {
           it("returns type location") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
             expect(result).notTo(beNil())
           }
         }
@@ -127,7 +127,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
         context("name does not match") {
           it("returns nil") {
             let sut = TypeLocationAnalyzer(typeName: "Bar")
-            let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
             expect(result).to(beNil())
           }
         }
@@ -153,7 +153,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
         context("name does not match") {
           it("returns nil") {
             let sut = TypeLocationAnalyzer(typeName: "Bar")
-            let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
             expect(result).to(beNil())
           }
         }
@@ -171,7 +171,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
             expect(result?.indexOfStartingLine) == 0
             expect(result?.indexOfEndingLine) == 0
           }
@@ -190,7 +190,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
             expect(result?.indexOfStartingLine) == 2
             expect(result?.indexOfEndingLine) == 2
           }
@@ -211,7 +211,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
            it("returns correct start and end indices") {
              let sut = TypeLocationAnalyzer(typeName: "Foo")
-             let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
              expect(result?.indexOfStartingLine) == 0
              expect(result?.indexOfEndingLine) == 2
            }
@@ -232,7 +232,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
            it("returns correct start and end indices") {
              let sut = TypeLocationAnalyzer(typeName: "Foo")
-             let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
              expect(result?.indexOfStartingLine) == 2
              expect(result?.indexOfEndingLine) == 4
            }
@@ -255,7 +255,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
             expect(result?.indexOfStartingLine) == 2
             expect(result?.indexOfEndingLine) == 6
           }
@@ -280,10 +280,33 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL)
+            let result = try? sut.analyze(fileURL: fileURL).first
             expect(result?.indexOfStartingLine) == 2
             expect(result?.indexOfEndingLine) == 8
           }
+        }
+      }
+      context("when multiple types with the same name exist") {
+        beforeEach {
+          let content =
+          """
+          struct Foo { }
+
+          class Bar {
+            enum Foo { }
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("returns correct start and end indices") {
+          let sut = TypeLocationAnalyzer(typeName: "Foo")
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.count).to(equal(2))
+          expect(result?.first?.indexOfStartingLine) == 0
+          expect(result?.first?.indexOfEndingLine) == 0
+          expect(result?.last?.indexOfStartingLine) == 3
+          expect(result?.last?.indexOfEndingLine) == 3
         }
       }
     }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -203,10 +203,10 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           beforeEach {
             let content =
             """
-             struct Foo {
-               let myProperty: String
-             }
-             """
+            struct Foo {
+              let myProperty: String
+            }
+            """
             fileURL = try? Temporary.makeFile(content: content)
           }
 
@@ -223,12 +223,12 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           beforeEach {
             let content =
             """
-             import Foundation
+            import Foundation
 
-             struct Foo {
-               let myProperty: String
-             }
-             """
+            struct Foo {
+              let myProperty: String
+            }
+            """
             fileURL = try? Temporary.makeFile(content: content)
           }
 

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -335,6 +335,28 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           expect(typeLocation?.indexOfEndingLine) == 2
         }
       }
+
+      context("when the type has modifiers on multiple lines") {
+        beforeEach {
+          let content =
+          """
+
+          public
+          final
+          class Foo {
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        fit("returns correct start and end indices") {
+          let sut = TypeLocationAnalyzer(typeName: "Foo")
+          let result = try? sut.analyze(fileURL: fileURL)
+          let typeLocation = result?.first
+          expect(typeLocation?.indexOfStartingLine) == 1
+          expect(typeLocation?.indexOfEndingLine) == 4
+        }
+      }
     }
   }
 }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -158,6 +158,44 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           }
         }
       }
+
+      context("type is one line") {
+        context("which is the first line of file") {
+          beforeEach {
+            let content =
+            """
+            enum Foo { }
+            """
+            fileURL = try? Temporary.makeFile(content: content)
+          }
+
+          it("returns correct start and end indices") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result?.indexOfStartingLine) == 0
+            expect(result?.indexOfEndingLine) == 0
+          }
+        }
+
+        context("which is not the first line of file") {
+          beforeEach {
+            let content =
+            """
+            import Foundation
+
+            enum Foo { }
+            """
+            fileURL = try? Temporary.makeFile(content: content)
+          }
+
+          it("returns correct start and end indices") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result?.indexOfStartingLine) == 2
+            expect(result?.indexOfEndingLine) == 2
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -195,6 +195,96 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
             expect(result?.indexOfEndingLine) == 2
           }
         }
+
+        context("type spans multiple lines") {
+          context("starting on the first line of the file") {
+             beforeEach {
+               let content =
+               """
+               struct Foo {
+                 let myProperty: String
+               }
+               """
+               fileURL = try? Temporary.makeFile(content: content)
+             }
+
+             it("returns correct start and end indices") {
+               let sut = TypeLocationAnalyzer(typeName: "Foo")
+               let result = try? sut.analyze(fileURL: fileURL)
+               expect(result?.indexOfStartingLine) == 0
+               expect(result?.indexOfEndingLine) == 2
+             }
+           }
+
+           context("starting on a line of the file that is not the first") {
+             beforeEach {
+               let content =
+               """
+               import Foundation
+
+               struct Foo {
+                 let myProperty: String
+               }
+               """
+               fileURL = try? Temporary.makeFile(content: content)
+             }
+
+             it("returns correct start and end indices") {
+               let sut = TypeLocationAnalyzer(typeName: "Foo")
+               let result = try? sut.analyze(fileURL: fileURL)
+               expect(result?.indexOfStartingLine) == 2
+               expect(result?.indexOfEndingLine) == 4
+             }
+           }
+
+          context("contains another single line type") {
+            beforeEach {
+              let content =
+              """
+              import Foundation
+
+              struct Foo {
+                let myProperty: String
+
+                enum Bar { }
+              }
+              """
+              fileURL = try? Temporary.makeFile(content: content)
+            }
+
+            it("returns correct start and end indices") {
+              let sut = TypeLocationAnalyzer(typeName: "Foo")
+              let result = try? sut.analyze(fileURL: fileURL)
+              expect(result?.indexOfStartingLine) == 2
+              expect(result?.indexOfEndingLine) == 6
+            }
+          }
+
+          context("contains another type that spans multiple lines") {
+            beforeEach {
+              let content =
+              """
+              import Foundation
+
+              struct Foo {
+                let myProperty: String
+
+                enum Bar {
+                  case myCase
+                }
+              }
+              """
+              fileURL = try? Temporary.makeFile(content: content)
+            }
+
+            it("returns correct start and end indices") {
+              let sut = TypeLocationAnalyzer(typeName: "Foo")
+              let result = try? sut.analyze(fileURL: fileURL)
+              expect(result?.indexOfStartingLine) == 2
+              expect(result?.indexOfEndingLine) == 8
+            }
+          }
+        }
       }
     }
   }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -27,14 +27,47 @@ import Quick
 @testable import SwiftInspectorCore
 
 final class TypeLocationAnalyzerSpec: QuickSpec {
-  private var fileURL: URL!
 
   override func spec() {
+    var fileURL: URL!
+
     afterEach {
-      guard let fileURL = self.fileURL else {
+      guard let fileURL = fileURL else {
         return
       }
       try? Temporary.removeItem(at: fileURL)
+    }
+
+    describe("analyze(fileURL:)") {
+      context("the type is not present") {
+        let content =
+        """
+        import Foundation
+        """
+        fileURL = try? Temporary.makeFile(content: content)
+
+        it("returns nil") {
+          let sut = TypeLocationAnalyzer(typeName: "Foo")
+          let result = try? sut.analyze(fileURL: fileURL)
+
+          expect(result).to(beNil())
+        }
+      }
+
+      context("struct is present") {
+        let content =
+        """
+        struct Foo { }
+        """
+        fileURL = try? Temporary.makeFile(content: content)
+
+        it("returns type location") {
+          let sut = TypeLocationAnalyzer(typeName: "Foo")
+          let result = try? sut.analyze(fileURL: fileURL)
+
+          expect(result).notTo(beNil())
+        }
+      }
     }
   }
 }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -63,11 +63,20 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           fileURL = try? Temporary.makeFile(content: content)
         }
 
-        it("returns type location") {
-          let sut = TypeLocationAnalyzer(typeName: "Foo")
-          let result = try? sut.analyze(fileURL: fileURL)
+        context("name matches") {
+          it("returns type location") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).notTo(beNil())
+          }
+        }
 
-          expect(result).notTo(beNil())
+        context("name does not match") {
+          it("returns nil") {
+            let sut = TypeLocationAnalyzer(typeName: "Bar")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).to(beNil())
+          }
         }
       }
 
@@ -81,11 +90,20 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
         }
 
-        it("returns type location") {
-          let sut = TypeLocationAnalyzer(typeName: "Foo")
-          let result = try? sut.analyze(fileURL: fileURL)
+        context("name matches") {
+          it("returns type location") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).notTo(beNil())
+          }
+        }
 
-          expect(result).notTo(beNil())
+        context("name does not match") {
+          it("returns nil") {
+            let sut = TypeLocationAnalyzer(typeName: "Bar")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).to(beNil())
+          }
         }
       }
 
@@ -98,11 +116,46 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           fileURL = try? Temporary.makeFile(content: content)
         }
 
-        it("returns type location") {
-          let sut = TypeLocationAnalyzer(typeName: "Foo")
-          let result = try? sut.analyze(fileURL: fileURL)
+        context("name matches") {
+          it("returns type location") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).notTo(beNil())
+          }
+        }
 
-          expect(result).notTo(beNil())
+        context("name does not match") {
+          it("returns nil") {
+            let sut = TypeLocationAnalyzer(typeName: "Bar")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).to(beNil())
+          }
+        }
+      }
+
+      context("protocol is present") {
+        beforeEach {
+          let content =
+          """
+          protocol Foo { }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        context("name matches") {
+          it("returns type location") {
+            let sut = TypeLocationAnalyzer(typeName: "Foo")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).notTo(beNil())
+          }
+        }
+
+        context("name does not match") {
+          it("returns nil") {
+            let sut = TypeLocationAnalyzer(typeName: "Bar")
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).to(beNil())
+          }
         }
       }
     }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -327,7 +327,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           fileURL = try? Temporary.makeFile(content: content)
         }
 
-        fit("returns correct start and end indices") {
+        it("returns correct start and end indices") {
           let sut = TypeLocationAnalyzer(typeName: "Foo")
           let result = try? sut.analyze(fileURL: fileURL)
           let typeLocation = result?.first
@@ -349,7 +349,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           fileURL = try? Temporary.makeFile(content: content)
         }
 
-        fit("returns correct start and end indices") {
+        it("returns correct start and end indices") {
           let sut = TypeLocationAnalyzer(typeName: "Foo")
           let result = try? sut.analyze(fileURL: fileURL)
           let typeLocation = result?.first

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -357,6 +357,49 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           expect(typeLocation?.indexOfEndingLine) == 4
         }
       }
+
+      context("when the type has an attribute") {
+        beforeEach {
+          let content =
+          """
+          import Foundation
+
+          @objc class Foo: NSObject {
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        fit("returns correct start and end indices") {
+          let sut = TypeLocationAnalyzer(typeName: "Foo")
+          let result = try? sut.analyze(fileURL: fileURL)
+          let typeLocation = result?.first
+          expect(typeLocation?.indexOfStartingLine) == 2
+          expect(typeLocation?.indexOfEndingLine) == 3
+        }
+      }
+
+      context("when the type has an attribute and modifiers") {
+        beforeEach {
+          let content =
+          """
+          import Foundation
+
+          @objc
+          public final class Foo: NSObject {
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("returns correct start and end indices") {
+          let sut = TypeLocationAnalyzer(typeName: "Foo")
+          let result = try? sut.analyze(fileURL: fileURL)
+          let typeLocation = result?.first
+          expect(typeLocation?.indexOfStartingLine) == 2
+          expect(typeLocation?.indexOfEndingLine) == 4
+        }
+      }
     }
   }
 }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -370,7 +370,7 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           fileURL = try? Temporary.makeFile(content: content)
         }
 
-        fit("returns correct start and end indices") {
+        it("returns correct start and end indices") {
           let sut = TypeLocationAnalyzer(typeName: "Foo")
           let result = try? sut.analyze(fileURL: fileURL)
           let typeLocation = result?.first

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -68,6 +68,36 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           expect(result).notTo(beNil())
         }
       }
+
+      context("enum is present") {
+        let content =
+        """
+        enum Foo { }
+        """
+        fileURL = try? Temporary.makeFile(content: content)
+
+        it("returns type location") {
+          let sut = TypeLocationAnalyzer(typeName: "Foo")
+          let result = try? sut.analyze(fileURL: fileURL)
+
+          expect(result).notTo(beNil())
+        }
+      }
+
+      context("class is present") {
+        let content =
+        """
+        class Foo { }
+        """
+        fileURL = try? Temporary.makeFile(content: content)
+
+        it("returns type location") {
+          let sut = TypeLocationAnalyzer(typeName: "Foo")
+          let result = try? sut.analyze(fileURL: fileURL)
+
+          expect(result).notTo(beNil())
+        }
+      }
     }
   }
 }

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -1,0 +1,23 @@
+// Created by Michael Bachand on 3/28/20.
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation

--- a/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeLocationAnalyzerSpec.swift
@@ -46,11 +46,10 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
         """
         fileURL = try? Temporary.makeFile(content: content)
 
-        it("returns nil") {
+        it("returns empty array") {
           let sut = TypeLocationAnalyzer(typeName: "Foo")
-          let result = try? sut.analyze(fileURL: fileURL).first
-
-          expect(result).to(beNil())
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result).to(beEmpty())
         }
       }
 
@@ -67,15 +66,15 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           it("returns type location") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
             let result = try? sut.analyze(fileURL: fileURL)
-            expect(result).notTo(beNil())
+            expect(result).notTo(beEmpty())
           }
         }
 
         context("name does not match") {
-          it("returns nil") {
+          it("returns empty array") {
             let sut = TypeLocationAnalyzer(typeName: "Bar")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result).to(beNil())
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).to(beEmpty())
           }
         }
       }
@@ -94,15 +93,15 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           it("returns type location") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
             let result = try? sut.analyze(fileURL: fileURL)
-            expect(result).notTo(beNil())
+            expect(result).notTo(beEmpty())
           }
         }
 
         context("name does not match") {
-          it("returns nil") {
+          it("returns empty array") {
             let sut = TypeLocationAnalyzer(typeName: "Bar")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result).to(beNil())
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).to(beEmpty())
           }
         }
       }
@@ -119,16 +118,16 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
         context("name matches") {
           it("returns type location") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result).notTo(beNil())
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).notTo(beEmpty())
           }
         }
 
         context("name does not match") {
-          it("returns nil") {
+          it("returns empty array") {
             let sut = TypeLocationAnalyzer(typeName: "Bar")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result).to(beNil())
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).to(beEmpty())
           }
         }
       }
@@ -146,15 +145,15 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
           it("returns type location") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
             let result = try? sut.analyze(fileURL: fileURL)
-            expect(result).notTo(beNil())
+            expect(result).notTo(beEmpty())
           }
         }
 
         context("name does not match") {
-          it("returns nil") {
+          it("returns empty array") {
             let sut = TypeLocationAnalyzer(typeName: "Bar")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result).to(beNil())
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result).to(beEmpty())
           }
         }
       }
@@ -171,9 +170,10 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result?.indexOfStartingLine) == 0
-            expect(result?.indexOfEndingLine) == 0
+            let result = try? sut.analyze(fileURL: fileURL)
+            let typeLocation = result?.first
+            expect(typeLocation?.indexOfStartingLine) == 0
+            expect(typeLocation?.indexOfEndingLine) == 0
           }
         }
 
@@ -190,9 +190,10 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result?.indexOfStartingLine) == 2
-            expect(result?.indexOfEndingLine) == 2
+            let result = try? sut.analyze(fileURL: fileURL)
+            let typeLocation = result?.first
+            expect(typeLocation?.indexOfStartingLine) == 2
+            expect(typeLocation?.indexOfEndingLine) == 2
           }
         }
       }
@@ -211,9 +212,10 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result?.indexOfStartingLine) == 0
-            expect(result?.indexOfEndingLine) == 2
+            let result = try? sut.analyze(fileURL: fileURL)
+            let typeLocation = result?.first
+            expect(typeLocation?.indexOfStartingLine) == 0
+            expect(typeLocation?.indexOfEndingLine) == 2
           }
         }
 
@@ -232,9 +234,10 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result?.indexOfStartingLine) == 2
-            expect(result?.indexOfEndingLine) == 4
+            let result = try? sut.analyze(fileURL: fileURL)
+            let typeLocation = result?.first
+            expect(typeLocation?.indexOfStartingLine) == 2
+            expect(typeLocation?.indexOfEndingLine) == 4
           }
         }
 
@@ -255,9 +258,10 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result?.indexOfStartingLine) == 2
-            expect(result?.indexOfEndingLine) == 6
+            let result = try? sut.analyze(fileURL: fileURL)
+            let typeLocation = result?.first
+            expect(typeLocation?.indexOfStartingLine) == 2
+            expect(typeLocation?.indexOfEndingLine) == 6
           }
         }
 
@@ -280,9 +284,10 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
           it("returns correct start and end indices") {
             let sut = TypeLocationAnalyzer(typeName: "Foo")
-            let result = try? sut.analyze(fileURL: fileURL).first
-            expect(result?.indexOfStartingLine) == 2
-            expect(result?.indexOfEndingLine) == 8
+            let result = try? sut.analyze(fileURL: fileURL)
+            let typeLocation = result?.first
+            expect(typeLocation?.indexOfStartingLine) == 2
+            expect(typeLocation?.indexOfEndingLine) == 8
           }
         }
       }
@@ -324,9 +329,10 @@ final class TypeLocationAnalyzerSpec: QuickSpec {
 
         fit("returns correct start and end indices") {
           let sut = TypeLocationAnalyzer(typeName: "Foo")
-          let result = try? sut.analyze(fileURL: fileURL).first
-          expect(result?.indexOfStartingLine) == 1
-          expect(result?.indexOfEndingLine) == 2
+          let result = try? sut.analyze(fileURL: fileURL)
+          let typeLocation = result?.first
+          expect(typeLocation?.indexOfStartingLine) == 1
+          expect(typeLocation?.indexOfEndingLine) == 2
         }
       }
     }

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -77,20 +77,11 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     }
 
     if let anyLocatedType = anyLocatedType {
-      var indexOfStartingLine = currentLineNumber
-      // We need to add this in early. We don't modify currentLineNumber since they will be added
-      // in later when we compute the leading newlines for this entire node.
-      indexOfStartingLine += countOfLeadingNewlinesForType(
-        keywordToken: anyLocatedType.keywordToken,
-        modifiers: anyLocatedType.modifiers)
-
-      let indexOfEndingLine = indexOfStartingLine + countOfNewlines(within: node)
-
-      let locatedType = LocatedType(
+      processLocatedType(
         name: anyLocatedType.name,
-        indexOfStartingLine: indexOfStartingLine,
-        indexOfEndingLine: indexOfEndingLine)
-      onNodeVisit(locatedType)
+        keywordToken: anyLocatedType.keywordToken,
+        modifiers: anyLocatedType.modifiers,
+        for: node)
     }
 
     if let leadingTrivia = node.leadingTrivia {
@@ -105,6 +96,29 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
 
   var currentLineNumber = 0
   let onNodeVisit: (LocatedType) -> Void
+
+  /// Compute the location of the type and invoke the callback.
+  private func processLocatedType(
+    name: String,
+    keywordToken: TokenSyntax,
+    modifiers: ModifierListSyntax?,
+    for node: Syntax)
+  {
+    var indexOfStartingLine = currentLineNumber
+    // We need to add this in early. We don't modify currentLineNumber since they will be added
+    // in later when we compute the leading newlines for this entire node.
+    indexOfStartingLine += countOfLeadingNewlinesForType(
+      keywordToken: keywordToken,
+      modifiers: modifiers)
+
+    let indexOfEndingLine = indexOfStartingLine + countOfNewlines(within: node)
+
+    let locatedType = LocatedType(
+      name: name,
+      indexOfStartingLine: indexOfStartingLine,
+      indexOfEndingLine: indexOfEndingLine)
+    onNodeVisit(locatedType)
+  }
 
   /// The total newlines associated with this node.
   private func countOfNewlines(from trivia: Trivia, for node: Syntax) -> Int {

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -108,6 +108,8 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
 
   /// The total newlines associated with this node.
   private func countOfNewlines(from trivia: Trivia, for node: Syntax) -> UInt {
+    // Some nodes seem to include trivia from other nodes. Filtering to just tokens ensures we get
+    // an accurate count.
     guard node is TokenSyntax else { return 0 }
     return trivia.countOfNewlines()
   }

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -21,3 +21,48 @@
 // SOFTWARE.
 
 import Foundation
+import SwiftSyntax
+
+public final class TypeLocationAnalyzer: Analyzer {
+
+  /// - Parameter cachedSyntaxTree: The cached syntax tree to return the AST tree from
+  public init(cachedSyntaxTree: CachedSyntaxTree = .init()) {
+    self.cachedSyntaxTree = cachedSyntaxTree
+  }
+
+  /// Analyzes the imports of the Swift file
+  /// - Parameter fileURL: The fileURL where the Swift file is located
+  public func analyze(fileURL: URL) throws -> TypeLocation? {
+    let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
+    var typeLocation: TypeLocation?
+    let reader = TypeLocationSyntaxReader() { node in
+      // TODO: create type location if possible
+      typeLocation = nil
+    }
+    _ = reader.visit(syntax)
+
+    return typeLocation
+  }
+
+  // MARK: Private
+
+  private let cachedSyntaxTree: CachedSyntaxTree
+}
+
+// TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
+private final class TypeLocationSyntaxReader: SyntaxRewriter {
+  // TODO: Update this to be the correct type.
+  init(onNodeVisit: @escaping (ImportDeclSyntax) -> Void) {
+    self.onNodeVisit = onNodeVisit
+  }
+
+  override func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
+    onNodeVisit(node)
+    return super.visit(node)
+  }
+
+  let onNodeVisit: (ImportDeclSyntax) -> Void
+}
+
+public struct TypeLocation: Hashable {
+}

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -61,27 +61,34 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
   }
 
   override func visitAny(_ node: Syntax) -> Syntax? {
-    let anyLocatedType: (name: String, keywordToken: TokenSyntax, modifiers: ModifierListSyntax?)?
-
     switch node {
     case let classDecl as ClassDeclSyntax:
-      anyLocatedType = (classDecl.identifier.text, classDecl.classKeyword, classDecl.modifiers)
-    case let enumDecl as EnumDeclSyntax:
-      anyLocatedType = (enumDecl.identifier.text, enumDecl.enumKeyword, enumDecl.modifiers)
-    case let protocolDecl as ProtocolDeclSyntax:
-      anyLocatedType = (protocolDecl.identifier.text, protocolDecl.protocolKeyword, protocolDecl.modifiers)
-    case let structDecl as StructDeclSyntax:
-      anyLocatedType = (structDecl.identifier.text, structDecl.structKeyword, structDecl.modifiers)
-    default:
-      anyLocatedType = nil
-    }
-
-    if let anyLocatedType = anyLocatedType {
       processLocatedType(
-        name: anyLocatedType.name,
-        keywordToken: anyLocatedType.keywordToken,
-        modifiers: anyLocatedType.modifiers,
+        name: classDecl.identifier.text,
+        keywordToken: classDecl.classKeyword,
+        modifiers: classDecl.modifiers,
         for: node)
+    case let enumDecl as EnumDeclSyntax:
+      processLocatedType(
+        name: enumDecl.identifier.text,
+        keywordToken: enumDecl.enumKeyword,
+        modifiers: enumDecl.modifiers,
+        for: node)
+    case let protocolDecl as ProtocolDeclSyntax:
+      processLocatedType(
+        name: protocolDecl.identifier.text,
+        keywordToken: protocolDecl.protocolKeyword,
+        modifiers: protocolDecl.modifiers,
+        for: node)
+    case let structDecl as StructDeclSyntax:
+      processLocatedType(
+        name: structDecl.identifier.text,
+        keywordToken: structDecl.structKeyword,
+        modifiers: structDecl.modifiers,
+        for: node)
+    default:
+      // Nothing to do here.
+      break
     }
 
     if let leadingTrivia = node.leadingTrivia {

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -37,7 +37,8 @@ public final class TypeLocationAnalyzer: Analyzer {
   public func analyze(fileURL: URL) throws -> TypeLocation? {
     let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
     var typeLocation: TypeLocation?
-    let reader = TypeLocationSyntaxReader() {
+    let reader = TypeLocationSyntaxReader() { [unowned self] typeName in
+      guard self.typeName == typeName else { return }
       typeLocation = TypeLocation(indexOfStartingLine: 0, indexOfEndingLine: 0)
     }
     _ = reader.visit(syntax)
@@ -53,31 +54,31 @@ public final class TypeLocationAnalyzer: Analyzer {
 
 // TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
 private final class TypeLocationSyntaxReader: SyntaxRewriter {
-  init(onNodeVisit: @escaping () -> Void) {
+  init(onNodeVisit: @escaping (_ typeName: String) -> Void) {
     self.onNodeVisit = onNodeVisit
   }
 
   override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
-    onNodeVisit()
+    onNodeVisit(node.identifier.text)
     return super.visit(node)
   }
 
   override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
-    onNodeVisit()
+    onNodeVisit(node.identifier.text)
     return super.visit(node)
   }
 
   override func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
-    onNodeVisit()
+    onNodeVisit(node.identifier.text)
     return super.visit(node)
   }
 
   override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
-    onNodeVisit()
+    onNodeVisit(node.identifier.text)
     return super.visit(node)
   }
 
-  let onNodeVisit: () -> Void
+  let onNodeVisit: (String) -> Void
 }
 
 /// Information about a located type. Indices start with 0.

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -103,7 +103,7 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     return super.visitAny(node)
   }
 
-  var currentLineNumber: Int = 0
+  var currentLineNumber = 0
   let onNodeVisit: (LocatedType) -> Void
 
   /// The total newlines associated with this node.
@@ -119,7 +119,7 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     keywordToken: TokenSyntax,
     modifiers: ModifierListSyntax?) -> Int
   {
-    var result: Int = 0
+    var result = 0
     result += keywordToken.leadingTrivia.countOfNewlines()
     modifiers?.leadingTrivia.flatMap { result += $0.countOfNewlines() }
     return result
@@ -127,7 +127,7 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
 
   /// Find the number of newlines within this node.
   private func countOfNewlines(within node: Syntax) -> Int {
-    var countOfNewlinesInsideType: Int = 0
+    var countOfNewlinesInsideType = 0
 
     for (offset, token) in node.tokens.enumerated() {
       // We've already counted the leading trivia for the first token.
@@ -160,7 +160,7 @@ public struct LocatedType: Hashable {
 extension Trivia {
 
   fileprivate func countOfNewlines() -> Int {
-    var result: Int = 0
+    var result = 0
     for triviaPiece in self {
       switch triviaPiece {
       case .newlines(let count):

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -141,7 +141,7 @@ private final class TypeLocationSyntaxVisitor: SyntaxVisitor {
     modifiers: ModifierListSyntax?) -> Int
   {
     // We know modifiers come before the keyword. So if have modifiers, we don't need to look at the
-    // token.
+    // keyword.
     if let modifiers = modifiers {
       return modifiers.leadingTrivia?.countOfNewlines() ?? 0
     }

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -62,38 +62,22 @@ private final class TypeLocationSyntaxVisitor: SyntaxVisitor {
   }
 
   func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    processLocatedType(
-      name: node.identifier.text,
-      keywordToken: node.classKeyword,
-      modifiers: node.modifiers,
-      for: node)
+    processLocatedType(name: node.identifier.text, keywordToken: node.classKeyword, for: node)
     return .visitChildren
   }
 
   func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    processLocatedType(
-      name: node.identifier.text,
-      keywordToken: node.enumKeyword,
-      modifiers: node.modifiers,
-      for: node)
+    processLocatedType(name: node.identifier.text, keywordToken: node.enumKeyword, for: node)
     return .visitChildren
   }
 
   func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    processLocatedType(
-      name: node.identifier.text,
-      keywordToken: node.protocolKeyword,
-      modifiers: node.modifiers,
-      for: node)
+    processLocatedType(name: node.identifier.text, keywordToken: node.protocolKeyword, for: node)
     return .visitChildren
   }
 
   func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    processLocatedType(
-      name: node.identifier.text,
-      keywordToken: node.structKeyword,
-      modifiers: node.modifiers,
-      for: node)
+    processLocatedType(name: node.identifier.text, keywordToken: node.structKeyword, for: node)
     return .visitChildren
   }
 
@@ -114,17 +98,10 @@ private final class TypeLocationSyntaxVisitor: SyntaxVisitor {
   private let onNodeVisit: (LocatedType) -> Void
 
   /// Compute the location of the type and invoke the callback.
-  private func processLocatedType(
-    name: String,
-    keywordToken: TokenSyntax,
-    modifiers: ModifierListSyntax?,
-    for node: Syntax)
-  {
+  private func processLocatedType(name: String, keywordToken: TokenSyntax, for node: Syntax) {
     var indexOfStartingLine = currentLineNumber
-    // `currentLineNumber` doesn't include leading trivia for this type. We compute it now.
-    indexOfStartingLine += countOfLeadingNewlinesForType(
-      keywordToken: keywordToken,
-      modifiers: modifiers)
+    // `currentLineNumber` doesn't yet include newlines from the leading trivia for the first token.
+    indexOfStartingLine += node.firstToken?.leadingTrivia.countOfNewlines() ?? 0
 
     let indexOfEndingLine = indexOfStartingLine + countOfNewlines(within: node)
 
@@ -133,21 +110,6 @@ private final class TypeLocationSyntaxVisitor: SyntaxVisitor {
       indexOfStartingLine: indexOfStartingLine,
       indexOfEndingLine: indexOfEndingLine)
     onNodeVisit(locatedType)
-  }
-
-  /// The number of newlines preceding the type.
-  private func countOfLeadingNewlinesForType(
-    keywordToken: TokenSyntax,
-    modifiers: ModifierListSyntax?) -> Int
-  {
-    // We know modifiers come before the keyword. So if have modifiers, we don't need to look at the
-    // keyword.
-    if let modifiers = modifiers {
-      return modifiers.leadingTrivia?.countOfNewlines() ?? 0
-    }
-    else {
-      return keywordToken.leadingTrivia.countOfNewlines()
-    }
   }
 
   /// Find the number of newlines within this node.

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -99,8 +99,10 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     return super.visit(node)
   }
 
-  // Tokens seem to be processed last
   override func visit(_ token: TokenSyntax) -> Syntax {
+    // Some nodes seem to include trivia from other nodes. Only counting newlines for trivia
+    // associated with tokens ensures we get an accurate count.
+    // Tokens are processed after `*DeclSyntax` nodes.
     if let leadingTrivia = token.leadingTrivia {
       currentLineNumber += countOfNewlines(from: leadingTrivia, for: token)
     }
@@ -135,8 +137,6 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
 
   /// The total newlines associated with this node.
   private func countOfNewlines(from trivia: Trivia, for node: Syntax) -> Int {
-    // Some nodes seem to include trivia from other nodes. Filtering to just tokens ensures we get
-    // an accurate count.
     guard node is TokenSyntax else { return 0 }
     return trivia.countOfNewlines()
   }

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -159,7 +159,7 @@ public struct LocatedType: Hashable {
 
 extension Trivia {
 
-  func countOfNewlines() -> UInt {
+  fileprivate func countOfNewlines() -> UInt {
     var result: UInt = 0
     for triviaPiece in self {
       switch triviaPiece {

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -120,8 +120,8 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     for node: Syntax)
   {
     var indexOfStartingLine = currentLineNumber
-    // We need to add this in early. We don't modify currentLineNumber since they will be added
-    // in later when we compute the leading newlines for this entire node.
+    // We need to add this in early. We rely on the token visitation method to update
+    // `currentLineNumber`.
     indexOfStartingLine += countOfLeadingNewlinesForType(
       keywordToken: keywordToken,
       modifiers: modifiers)

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -103,11 +103,11 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     return super.visitAny(node)
   }
 
-  var currentLineNumber: UInt = 0
+  var currentLineNumber: Int = 0
   let onNodeVisit: (LocatedType) -> Void
 
   /// The total newlines associated with this node.
-  private func countOfNewlines(from trivia: Trivia, for node: Syntax) -> UInt {
+  private func countOfNewlines(from trivia: Trivia, for node: Syntax) -> Int {
     // Some nodes seem to include trivia from other nodes. Filtering to just tokens ensures we get
     // an accurate count.
     guard node is TokenSyntax else { return 0 }
@@ -117,17 +117,17 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
   /// The number of newlines preceding this token.
   private func countOfLeadingNewlinesForType(
     keywordToken: TokenSyntax,
-    modifiers: ModifierListSyntax?) -> UInt
+    modifiers: ModifierListSyntax?) -> Int
   {
-    var result: UInt = 0
+    var result: Int = 0
     result += keywordToken.leadingTrivia.countOfNewlines()
     modifiers?.leadingTrivia.flatMap { result += $0.countOfNewlines() }
     return result
   }
 
   /// Find the number of newlines within this node.
-  private func countOfNewlines(within node: Syntax) -> UInt {
-    var countOfNewlinesInsideType: UInt = 0
+  private func countOfNewlines(within node: Syntax) -> Int {
+    var countOfNewlinesInsideType: Int = 0
 
     for (offset, token) in node.tokens.enumerated() {
       // We've already counted the leading trivia for the first token.
@@ -150,21 +150,21 @@ public struct LocatedType: Hashable {
   /// The name of the type.
   public let name: String
   /// The first line of the type.
-  public let indexOfStartingLine: UInt
+  public let indexOfStartingLine: Int
   /// The last line of the type.
-  public let indexOfEndingLine: UInt
+  public let indexOfEndingLine: Int
 }
 
 // MARK: Trivia
 
 extension Trivia {
 
-  fileprivate func countOfNewlines() -> UInt {
-    var result: UInt = 0
+  fileprivate func countOfNewlines() -> Int {
+    var result: Int = 0
     for triviaPiece in self {
       switch triviaPiece {
       case .newlines(let count):
-        result += UInt(count)
+        result += count
       default:
         break
       }

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -27,7 +27,7 @@ import SwiftSyntax
 
 public final class TypeLocationAnalyzer: Analyzer {
 
-  /// - Parameter typeName: The name of the type to locate.
+  /// - Parameter typeName: The name of the type to locate
   /// - Parameter cachedSyntaxTree: The cached syntax tree to return the AST tree from
   public init(typeName: String, cachedSyntaxTree: CachedSyntaxTree = .init()) {
     self.typeName = typeName

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -58,24 +58,20 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     self.onNodeVisit = onNodeVisit
   }
 
-  override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
-    onNodeVisit(node.identifier.text)
-    return super.visit(node)
-  }
-
-  override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
-    onNodeVisit(node.identifier.text)
-    return super.visit(node)
-  }
-
-  override func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
-    onNodeVisit(node.identifier.text)
-    return super.visit(node)
-  }
-
-  override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
-    onNodeVisit(node.identifier.text)
-    return super.visit(node)
+  override func visitAny(_ node: Syntax) -> Syntax? {
+    switch node {
+    case let classDecl as ClassDeclSyntax:
+      onNodeVisit(classDecl.identifier.text)
+    case let enumDecl as EnumDeclSyntax:
+      onNodeVisit(enumDecl.identifier.text)
+    case let protocolDecl as ProtocolDeclSyntax:
+      onNodeVisit(protocolDecl.identifier.text)
+    case let structDecl as StructDeclSyntax:
+      onNodeVisit(structDecl.identifier.text)
+    default:
+      break
+    }
+    return super.visitAny(node)
   }
 
   let onNodeVisit: (String) -> Void

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -60,49 +60,55 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     self.onNodeVisit = onNodeVisit
   }
 
-  override func visitAny(_ node: Syntax) -> Syntax? {
-    switch node {
-    case let classDecl as ClassDeclSyntax:
-      processLocatedType(
-        name: classDecl.identifier.text,
-        keywordToken: classDecl.classKeyword,
-        modifiers: classDecl.modifiers,
-        for: node)
-    case let enumDecl as EnumDeclSyntax:
-      processLocatedType(
-        name: enumDecl.identifier.text,
-        keywordToken: enumDecl.enumKeyword,
-        modifiers: enumDecl.modifiers,
-        for: node)
-    case let protocolDecl as ProtocolDeclSyntax:
-      processLocatedType(
-        name: protocolDecl.identifier.text,
-        keywordToken: protocolDecl.protocolKeyword,
-        modifiers: protocolDecl.modifiers,
-        for: node)
-    case let structDecl as StructDeclSyntax:
-      processLocatedType(
-        name: structDecl.identifier.text,
-        keywordToken: structDecl.structKeyword,
-        modifiers: structDecl.modifiers,
-        for: node)
-    default:
-      // Nothing to do here.
-      break
-    }
-
-    if let leadingTrivia = node.leadingTrivia {
-      currentLineNumber += countOfNewlines(from: leadingTrivia, for: node)
-    }
-    if let trailingTrivia = node.trailingTrivia {
-      currentLineNumber += countOfNewlines(from: trailingTrivia, for: node)
-    }
-
-    return super.visitAny(node)
-  }
-
   var currentLineNumber = 0
   let onNodeVisit: (LocatedType) -> Void
+
+  override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
+    processLocatedType(
+      name: node.identifier.text,
+      keywordToken: node.classKeyword,
+      modifiers: node.modifiers,
+      for: node)
+    return super.visit(node)
+  }
+
+  override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
+    processLocatedType(
+      name: node.identifier.text,
+      keywordToken: node.enumKeyword,
+      modifiers: node.modifiers,
+      for: node)
+    return super.visit(node)
+  }
+
+  override func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
+    processLocatedType(
+      name: node.identifier.text,
+      keywordToken: node.protocolKeyword,
+      modifiers: node.modifiers,
+      for: node)
+    return super.visit(node)
+  }
+
+  override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
+    processLocatedType(
+      name: node.identifier.text,
+      keywordToken: node.structKeyword,
+      modifiers: node.modifiers,
+      for: node)
+    return super.visit(node)
+  }
+
+  // Tokens seem to be processed last
+  override func visit(_ token: TokenSyntax) -> Syntax {
+    if let leadingTrivia = token.leadingTrivia {
+      currentLineNumber += countOfNewlines(from: leadingTrivia, for: token)
+    }
+    if let trailingTrivia = token.trailingTrivia {
+      currentLineNumber += countOfNewlines(from: trailingTrivia, for: token)
+    }
+    return super.visit(token)
+  }
 
   /// Compute the location of the type and invoke the callback.
   private func processLocatedType(

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -34,7 +34,7 @@ public final class TypeLocationAnalyzer: Analyzer {
     self.cachedSyntaxTree = cachedSyntaxTree
   }
 
-  /// Analyzes the imports of the Swift file
+  /// Finds the location(s) of the specified type name in the Swift file
   /// - Parameter fileURL: The fileURL where the Swift file is located
   public func analyze(fileURL: URL) throws -> [LocatedType] {
     let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -104,10 +104,10 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     // associated with tokens ensures we get an accurate count.
     // Tokens are processed after `*DeclSyntax` nodes.
     if let leadingTrivia = token.leadingTrivia {
-      currentLineNumber += countOfNewlines(from: leadingTrivia, for: token)
+      currentLineNumber += leadingTrivia.countOfNewlines()
     }
     if let trailingTrivia = token.trailingTrivia {
-      currentLineNumber += countOfNewlines(from: trailingTrivia, for: token)
+      currentLineNumber += trailingTrivia.countOfNewlines()
     }
     return super.visit(token)
   }
@@ -133,12 +133,6 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
       indexOfStartingLine: indexOfStartingLine,
       indexOfEndingLine: indexOfEndingLine)
     onNodeVisit(locatedType)
-  }
-
-  /// The total newlines associated with this node.
-  private func countOfNewlines(from trivia: Trivia, for node: Syntax) -> Int {
-    guard node is TokenSyntax else { return 0 }
-    return trivia.countOfNewlines()
   }
 
   /// The number of newlines preceding this token.

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -37,9 +37,8 @@ public final class TypeLocationAnalyzer: Analyzer {
   public func analyze(fileURL: URL) throws -> TypeLocation? {
     let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
     var typeLocation: TypeLocation?
-    let reader = TypeLocationSyntaxReader() { node in
-      // TODO: create type location if possible
-      typeLocation = nil
+    let reader = TypeLocationSyntaxReader() {
+      typeLocation = TypeLocation(indexOfStartingLine: 0, indexOfEndingLine: 0)
     }
     _ = reader.visit(syntax)
 
@@ -54,17 +53,31 @@ public final class TypeLocationAnalyzer: Analyzer {
 
 // TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
 private final class TypeLocationSyntaxReader: SyntaxRewriter {
-  // TODO: Update this to be the correct type.
-  init(onNodeVisit: @escaping (ImportDeclSyntax) -> Void) {
+  init(onNodeVisit: @escaping () -> Void) {
     self.onNodeVisit = onNodeVisit
   }
 
-  override func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
-    onNodeVisit(node)
+  override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
+    onNodeVisit()
     return super.visit(node)
   }
 
-  let onNodeVisit: (ImportDeclSyntax) -> Void
+  override func visit(_ node: EnumDeclSyntax) -> DeclSyntax {
+    onNodeVisit()
+    return super.visit(node)
+  }
+
+  override func visit(_ node: ProtocolDeclSyntax) -> DeclSyntax {
+    onNodeVisit()
+    return super.visit(node)
+  }
+
+  override func visit(_ node: StructDeclSyntax) -> DeclSyntax {
+    onNodeVisit()
+    return super.visit(node)
+  }
+
+  let onNodeVisit: () -> Void
 }
 
 /// Information about a located type. Indices start with 0.

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -25,8 +25,10 @@ import SwiftSyntax
 
 public final class TypeLocationAnalyzer: Analyzer {
 
+  /// - Parameter typeName: The name of the type to locate.
   /// - Parameter cachedSyntaxTree: The cached syntax tree to return the AST tree from
-  public init(cachedSyntaxTree: CachedSyntaxTree = .init()) {
+  public init(typeName: String, cachedSyntaxTree: CachedSyntaxTree = .init()) {
+    self.typeName = typeName
     self.cachedSyntaxTree = cachedSyntaxTree
   }
 
@@ -47,6 +49,7 @@ public final class TypeLocationAnalyzer: Analyzer {
   // MARK: Private
 
   private let cachedSyntaxTree: CachedSyntaxTree
+  private let typeName: String
 }
 
 // TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -121,8 +121,7 @@ private final class TypeLocationSyntaxVisitor: SyntaxVisitor {
     for node: Syntax)
   {
     var indexOfStartingLine = currentLineNumber
-    // We need to add this in early. We rely on the token visitation method to update
-    // `currentLineNumber`.
+    // `currentLineNumber` doesn't include leading trivia for this type. We compute it now.
     indexOfStartingLine += countOfLeadingNewlinesForType(
       keywordToken: keywordToken,
       modifiers: modifiers)
@@ -136,15 +135,19 @@ private final class TypeLocationSyntaxVisitor: SyntaxVisitor {
     onNodeVisit(locatedType)
   }
 
-  /// The number of newlines preceding this token.
+  /// The number of newlines preceding the type.
   private func countOfLeadingNewlinesForType(
     keywordToken: TokenSyntax,
     modifiers: ModifierListSyntax?) -> Int
   {
-    var result = 0
-    result += keywordToken.leadingTrivia.countOfNewlines()
-    modifiers?.leadingTrivia.flatMap { result += $0.countOfNewlines() }
-    return result
+    // We know modifiers come before the keyword. So if have modifiers, we don't need to look at the
+    // token.
+    if let modifiers = modifiers {
+      return modifiers.leadingTrivia?.countOfNewlines() ?? 0
+    }
+    else {
+      return keywordToken.leadingTrivia.countOfNewlines()
+    }
   }
 
   /// Find the number of newlines within this node.

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -1,0 +1,23 @@
+// Created by Michael Bachand on 3/28/20.
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -64,5 +64,10 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
   let onNodeVisit: (ImportDeclSyntax) -> Void
 }
 
+/// Information about a located type. Indices start with 0.
 public struct TypeLocation: Hashable {
+  /// The first line of the type.
+  public let indexOfStartingLine: UInt
+  /// The last line of the type.
+  public let indexOfEndingLine: UInt
 }

--- a/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift
@@ -60,9 +60,6 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     self.onNodeVisit = onNodeVisit
   }
 
-  var currentLineNumber = 0
-  let onNodeVisit: (LocatedType) -> Void
-
   override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
     processLocatedType(
       name: node.identifier.text,
@@ -111,6 +108,9 @@ private final class TypeLocationSyntaxReader: SyntaxRewriter {
     }
     return super.visit(token)
   }
+
+  private var currentLineNumber = 0
+  private let onNodeVisit: (LocatedType) -> Void
 
   /// Compute the location of the type and invoke the callback.
   private func processLocatedType(

--- a/Sources/SwiftInspectorCore/TypealiasAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypealiasAnalyzer.swift
@@ -32,7 +32,7 @@ public final class TypealiasAnalyzer: Analyzer {
     self.cachedSyntaxTree = cachedSyntaxTree
   }
 
-  /// Analyzes the imports of the Swift file
+  /// Analyzes the matching initializers of the Swift file
   /// - Parameter fileURL: The fileURL where the Swift file is located
   public func analyze(fileURL: URL) throws -> [TypealiasStatement] {
     let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)


### PR DESCRIPTION
This PR is best reviewed in files changed view.

## The change

This command allows you to find the lines of a file that contain a type declaration.

```
OVERVIEW: Finds the line numbers on which a type is declared

USAGE: SwiftInspector type-location --name <name> --path <path>

OPTIONS:
  --name <name>           The name of the type to find the location of 
        This may be a enum, class, struct, or protocol.
  --path <path>           The absolute path to the file to inspect 
  -h, --help              Show help information.
```

This command can be useful if you are trying to move code. It allows you to find a type definition within a file and extract it easily.

The command returns the start and end index of the type. So if your type starts on line 2 (0 indexed) and ends on line 4, you will get back.

```
$ swiftinspector --name Foo --path /MyFile.swift
2 4
```

If multiple types with this name are found, you will get back one line for each type.

```
$ swiftinspector --name Foo --path /MyFileWithMultipleOfTheSameType.swift
2 4
10 13
```

## Testing

I wrote lots of tests. Also, if you run this command on the code I wrote, it works. Remember that it returns 0 indexed line numbers!

(I checked that all of these were correct when I ran them. If the code changes as this PR evolves they may not match up to this PR)

```shell
$ SwiftInspector type-location --name TypeLocationCommand --path /Users/me/repos/SwiftInspector/Sources/SwiftInspectorCommands/TypeLocationCommand.swift
28 70
```

```shell
$ SwiftInspector type-location --name TypeLocationAnalyzer --path /Users/me/repos/SwiftInspector/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift 
27 53
```

```shell
$ SwiftInspector type-location --name TypeLocationSyntaxVisitor --path /Users/me/repos/SwiftInspector/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift 
57 130
```

```shell
$ SwiftInspector type-location --name LocatedType --path /Users/me/repos/SwiftInspector/Sources/SwiftInspectorCore/TypeLocationAnalyzer.swift 
135 142
```


## Future work

It would be cool to have a way to find extension of a type too.

Could also be useful to have a way to include documentation comments above a type.

