### PR TITLE
Add initializer command

### DIFF
--- a/Sources/SwiftInspectorCommands/ImportsCommand.swift
+++ b/Sources/SwiftInspectorCommands/ImportsCommand.swift
@@ -47,7 +47,7 @@ final class ImportsCommand: ParsableCommand {
     let outputArray = try FileManager.default.swiftFiles(at: fileURL)
       .reduce(Set<String>()) { result, url in
         let importStatements = try analyzer.analyze(fileURL: url)
-        let output = importStatements.map { outputString(from: $0)}
+        let output = importStatements.map { outputString(from: $0) }
         return result.union(output)
     }
 
@@ -61,7 +61,7 @@ final class ImportsCommand: ParsableCommand {
       throw InspectorError.emptyArgument(argumentName: "--path")
     }
     guard FileManager.default.fileExists(atPath: path) else {
-      throw InspectorError.invalidArgument(argumentName: "--path", value: "options.path")
+      throw InspectorError.invalidArgument(argumentName: "--path", value: path)
     }
   }
 

--- a/Sources/SwiftInspectorCommands/InitializerCommand.swift
+++ b/Sources/SwiftInspectorCommands/InitializerCommand.swift
@@ -35,10 +35,10 @@ final class InitializerCommand: ParsableCommand {
   @Option(help: "The absolute path to the file to inspect")
   var path: String
 
-  @Option(help: "The name of the type to look information of the initializer")
+  @Option(help: "The name of the type whose initializer information we'll be looking for")
   var name: String
 
-  @Flag(name: .shortAndLong, default: true, inversion: .prefixedEnableDisable, help: Help.typeOnly)
+  @Flag(name: .shortAndLong, default: true, inversion: .prefixedEnableDisable, help: typeOnlyHelp)
   var typeOnly: Bool
 
   /// Runs the command
@@ -48,7 +48,7 @@ final class InitializerCommand: ParsableCommand {
     let fileURL = URL(fileURLWithPath: path)
 
     let initializerStatements = try analyzer.analyze(fileURL: fileURL)
-    let outputArray = initializerStatements.map { outputString(from: $0)}
+    let outputArray = initializerStatements.map { outputString(from: $0) }
 
     let output = outputArray.joined(separator: "\n")
     print(output)
@@ -63,7 +63,7 @@ final class InitializerCommand: ParsableCommand {
       throw InspectorError.emptyArgument(argumentName: "--path")
     }
     guard FileManager.default.fileExists(atPath: path) else {
-      throw InspectorError.invalidArgument(argumentName: "--path", value: "options.path")
+      throw InspectorError.invalidArgument(argumentName: "--path", value: path)
     }
   }
 
@@ -76,9 +76,7 @@ final class InitializerCommand: ParsableCommand {
   }
 }
 
-private enum Help {
-  static var typeOnly: ArgumentHelp = ArgumentHelp("The granularity of the output",
-                                                   discussion: """
-                                                    Outputs a list of the type names by default. If disabled it outputs the name of the parameter and the name of the type (e.g. 'foo,Int bar,String')
-                                                    """)
-}
+private var typeOnlyHelp = ArgumentHelp("The granularity of the output",
+                                        discussion: """
+                                        Outputs a list of the type names by default. If disabled it outputs the name of the parameter and the name of the type (e.g. 'foo,Int bar,String')
+                                        """)

--- a/Sources/SwiftInspectorCommands/InitializerCommand.swift
+++ b/Sources/SwiftInspectorCommands/InitializerCommand.swift
@@ -1,0 +1,25 @@
+// Created by Francisco Diaz on 3/27/20.
+//
+// Copyright (c) 2020 Francisco Diaz
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation

--- a/Sources/SwiftInspectorCommands/InitializerCommand.swift
+++ b/Sources/SwiftInspectorCommands/InitializerCommand.swift
@@ -22,4 +22,36 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import ArgumentParser
 import Foundation
+import SwiftInspectorCore
+
+final class InitializerCommand: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "initializer",
+    abstract: "Finds information about the initializers of the specified type"
+  )
+
+  @Option(help: "The absolute path to the file or directory to inspect")
+  var path: String
+
+  @Option(help: "The name of the type to look information of the initializer")
+  var name: String
+
+  /// Runs the command
+  func run() throws {
+  }
+
+  /// Validates if the arguments of this command are valid
+  func validate() throws {
+    guard !name.isEmpty else {
+      throw InspectorError.emptyArgument(argumentName: "--name")
+    }
+    guard !path.isEmpty else {
+      throw InspectorError.emptyArgument(argumentName: "--path")
+    }
+    guard FileManager.default.fileExists(atPath: path) else {
+      throw InspectorError.invalidArgument(argumentName: "--path", value: "options.path")
+    }
+  }
+}

--- a/Sources/SwiftInspectorCommands/InspectorCommand.swift
+++ b/Sources/SwiftInspectorCommands/InspectorCommand.swift
@@ -32,6 +32,7 @@ public struct InspectorCommand: ParsableCommand {
     abstract: "A command line tool to help inspect usage of classes, protocols, properties, etc in a Swift codebase.",
     subcommands: [
       ImportsCommand.self,
+      InitializerCommand.self,
       StaticUsageCommand.self,
       TypealiasCommand.self,
       TypeConformanceCommand.self,

--- a/Sources/SwiftInspectorCommands/StaticUsageCommand.swift
+++ b/Sources/SwiftInspectorCommands/StaticUsageCommand.swift
@@ -60,7 +60,7 @@ final class StaticUsageCommand: ParsableCommand {
       throw InspectorError.emptyArgument(argumentName: "--path")
     }
     guard FileManager.default.fileExists(atPath: path) else {
-      throw InspectorError.invalidArgument(argumentName: "--path", value: "options.path")
+      throw InspectorError.invalidArgument(argumentName: "--path", value: path)
     }
   }
 

--- a/Sources/SwiftInspectorCommands/Tests/ImportCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/ImportCommandSpec.swift
@@ -28,9 +28,7 @@ import Foundation
 
 @testable import SwiftInspectorCore
 
-final class InspectorCommandSpec: QuickSpec {
-  private var fileURL: URL!
-
+final class ImportCommandSpec: QuickSpec {
   override func spec() {
     describe("run") {
 

--- a/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
@@ -55,7 +55,11 @@ final class InitializerCommandSpec: QuickSpec {
         var fileURL: URL!
 
         beforeEach {
-          fileURL = try? Temporary.makeFile(content: "")
+          fileURL = try? Temporary.makeFile(content: """
+          final class Some {
+            init(some: String, someInt: Int) {}
+          }
+          """)
         }
 
         afterEach {
@@ -68,8 +72,18 @@ final class InitializerCommandSpec: QuickSpec {
         }
 
         it("succeeds") {
-          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "SomeName"])
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some"])
           expect(result?.didSucceed) == true
+        }
+
+        it("returns only the type names by default") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some"])
+          expect(result?.outputMessage).to(contain("String Int"))
+        }
+
+        it("returns the name and type name if we disable type only") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--disable-type-only"])
+          expect(result?.outputMessage).to(contain("some,String someInt,Int"))
         }
       }
 

--- a/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
@@ -1,0 +1,25 @@
+// Created by Francisco Diaz on 3/27/20.
+//
+// Copyright (c) 2020 Francisco Diaz
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation

--- a/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
@@ -22,4 +22,57 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import Nimble
+import Quick
 import Foundation
+
+@testable import SwiftInspectorCore
+
+final class InitializerCommandSpec: QuickSpec {
+  override func spec() {
+    describe("run") {
+
+      context("with no arguments") {
+        it("fails") {
+          let result = try? TestTask.run(withArguments: ["initializer"])
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("when path is invalid") {
+        it("fails when empty") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", ""])
+          expect(result?.didFail) == true
+        }
+
+        it("fails when it doesn't exist") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", "/fake/path"])
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("when name is passed and path exists") {
+        var fileURL: URL!
+
+        beforeEach {
+          fileURL = try? Temporary.makeFile(content: "")
+        }
+
+        afterEach {
+          try? Temporary.removeItem(at: fileURL)
+        }
+
+        it("fails when name is empty") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", ""])
+          expect(result?.didFail) == true
+        }
+
+        it("succeeds") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "SomeName"])
+          expect(result?.didSucceed) == true
+        }
+      }
+
+    }
+  }
+}

--- a/Sources/SwiftInspectorCommands/TypealiasCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypealiasCommand.swift
@@ -46,7 +46,7 @@ final class TypealiasCommand: ParsableCommand {
     let outputArray = try FileManager.default.swiftFiles(at: fileURL)
       .reduce(Set<String>()) { result, url in
         let statements = try analyzer.analyze(fileURL: url)
-        let output = filterOutput(statements).map { outputString(from: $0)}
+        let output = filterOutput(statements).map { outputString(from: $0) }
         return result.union(output)
     }
 

--- a/Sources/SwiftInspectorCore/InitializerAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/InitializerAnalyzer.swift
@@ -1,0 +1,25 @@
+// Created by Francisco Diaz on 3/27/20.
+//
+// Copyright (c) 2020 Francisco Diaz
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation

--- a/Sources/SwiftInspectorCore/InitializerAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/InitializerAnalyzer.swift
@@ -123,8 +123,8 @@ public struct InitializerStatement: Equatable {
 
 
   public struct Parameter: Equatable {
-    let name: String
-    let typeName: String
+    public let name: String
+    public let typeName: String
   }
 
   public struct Modifier: Equatable, OptionSet  {

--- a/Sources/SwiftInspectorCore/InitializerAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/InitializerAnalyzer.swift
@@ -23,3 +23,160 @@
 // SOFTWARE.
 
 import Foundation
+import SwiftSyntax
+
+public final class InitializerAnalyzer: Analyzer {
+  /// - Parameter cachedSyntaxTree: The cached syntax tree to return the AST tree from
+  public init(name: String, cachedSyntaxTree: CachedSyntaxTree = .init()) {
+    self.name = name
+    self.cachedSyntaxTree = cachedSyntaxTree
+  }
+
+  public func analyze(fileURL: URL) throws -> [InitializerStatement] {
+    var statements: [InitializerStatement] = []
+    let syntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
+
+    var reader = InitializerSyntaxReader(shouldVisitIdentifier: shouldVisit) { [unowned self] node in
+      let statement = self.initializerStatement(from: node)
+      statements.append(statement)
+    }
+    syntax.walk(&reader)
+
+    return statements
+  }
+
+  // MARK: Private
+  private let name: String
+  private let cachedSyntaxTree: CachedSyntaxTree
+
+  private func shouldVisit(_ identifier: String) -> Bool {
+    identifier == name
+  }
+
+  private func initializerStatement(from node: InitializerDeclSyntax) -> InitializerStatement {
+    let parameters = findParameters(from: node)
+    let modifiers = findModifiers(from: node)
+    return InitializerStatement(typeName: name, parameters: parameters, modifiers: modifiers)
+  }
+
+  private func findParameters(from node: InitializerDeclSyntax) -> [InitializerStatement.Parameter] {
+    let functionList = node.children
+      .compactMap { $0 as? ParameterClauseSyntax }
+      .first?.children
+      .compactMap { $0 as? FunctionParameterListSyntax }
+      .first
+
+    guard let list = functionList else {
+      return []
+    }
+
+    var parameters: [InitializerStatement.Parameter] = []
+
+    for parameterNode in list {
+      let parameter = findParameter(from: parameterNode)
+      parameters.append(parameter)
+    }
+
+    return parameters
+  }
+
+  private func findParameter(from node: FunctionParameterSyntax) -> InitializerStatement.Parameter {
+    let name = node.firstName?.text ?? ""
+    let typeName = node.children.compactMap { $0 as? SimpleTypeIdentifierSyntax }.first?.name.text ?? ""
+
+    return .init(name: name, typeName: typeName)
+  }
+
+  private func findModifiers(from node: InitializerDeclSyntax) -> InitializerStatement.Modifier {
+    let modifiersString: [String] = node.children
+      .compactMap { $0 as? ModifierListSyntax }
+      .reduce(into: []) { result, syntax in
+        let modifiers = syntax.children
+          .compactMap { $0 as? DeclModifierSyntax }
+          .map { $0.name.text }
+        result.append(contentsOf: modifiers)
+      }
+
+    var modifier = modifiersString.reduce(InitializerStatement.Modifier()) { result, stringValue in
+      let modifier = InitializerStatement.Modifier(stringValue: stringValue)
+      return result.union(modifier)
+    }
+
+    // If there are no explicit modifiers, this is a designated initializer
+    guard !modifier.isEmpty else {
+      return .designated
+    }
+
+    // If an initializer is not a convenience initializer, it's a designated initializer
+    if !modifier.contains(.convenience) {
+      modifier = modifier.union(.designated)
+    }
+
+    return modifier
+  }
+}
+
+public struct InitializerStatement: Equatable {
+  public let typeName: String
+  public let parameters: [Parameter]
+  public let modifiers: Modifier
+
+
+  public struct Parameter: Equatable {
+    let name: String
+    let typeName: String
+  }
+
+  public struct Modifier: Equatable, OptionSet  {
+    public let rawValue: Int
+
+    public static let designated = Modifier(rawValue: 1 << 0)
+    public static let convenience = Modifier(rawValue: 1 << 1)
+    public static let override = Modifier(rawValue: 1 << 2)
+    public static let required = Modifier(rawValue: 1 << 3)
+
+    public init(rawValue: Int)  {
+      self.rawValue = rawValue
+    }
+
+    public init(stringValue: String) {
+      switch stringValue {
+      case "convenience": self = .convenience
+      case "override": self = .override
+      case "required": self = .required
+      default: self = []
+      }
+    }
+  }
+}
+
+private final class InitializerSyntaxReader: SyntaxVisitor {
+  init(
+    shouldVisitIdentifier: @escaping (String) -> Bool,
+    onNodeVisit: @escaping (InitializerDeclSyntax) -> Void
+  )
+  {
+    self.shouldVisitIdentifier = shouldVisitIdentifier
+    self.onNodeVisit = onNodeVisit
+  }
+
+  func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    shouldVisitIdentifier(node.identifier.text) ? .visitChildren : .skipChildren
+  }
+
+  func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    shouldVisitIdentifier(node.identifier.text) ? .visitChildren : .skipChildren
+  }
+
+  func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    shouldVisitIdentifier(node.identifier.text) ? .visitChildren : .skipChildren
+  }
+
+  func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+    onNodeVisit(node)
+    return .visitChildren
+  }
+
+  let shouldVisitIdentifier: (String) -> Bool
+  let onNodeVisit: (InitializerDeclSyntax) -> Void
+}

--- a/Sources/SwiftInspectorCore/Tests/ImportsAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/ImportsAnalyzerSpec.swift
@@ -45,7 +45,7 @@ final class ImportsAnalyzerSpec: QuickSpec {
                       public final class Some {
                       }
                       """
-        self.fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+        self.fileURL = try? Temporary.makeFile(content: content)
 
         it("returns an empty array") {
           let sut = ImportsAnalyzer()
@@ -64,7 +64,7 @@ final class ImportsAnalyzerSpec: QuickSpec {
                         public final class Some {
                         }
                         """
-          self.fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+          self.fileURL = try? Temporary.makeFile(content: content)
           sut = try? ImportsAnalyzer().analyze(fileURL: self.fileURL)
         }
 
@@ -90,7 +90,7 @@ final class ImportsAnalyzerSpec: QuickSpec {
 
                         public final class Some {}
                         """
-          self.fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+          self.fileURL = try? Temporary.makeFile(content: content)
           sut = try? ImportsAnalyzer().analyze(fileURL: self.fileURL)
         }
 
@@ -108,7 +108,7 @@ final class ImportsAnalyzerSpec: QuickSpec {
                         public final class Some {
                         }
                         """
-          self.fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+          self.fileURL = try? Temporary.makeFile(content: content)
           sut = try? ImportsAnalyzer().analyze(fileURL: self.fileURL)
         }
 
@@ -135,7 +135,7 @@ final class ImportsAnalyzerSpec: QuickSpec {
                         public final class Some {
                         }
                         """
-          self.fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+          self.fileURL = try? Temporary.makeFile(content: content)
           sut = try? ImportsAnalyzer().analyze(fileURL: self.fileURL)
         }
 
@@ -163,7 +163,7 @@ final class ImportsAnalyzerSpec: QuickSpec {
                         public final class Some {
                         }
                         """
-          self.fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+          self.fileURL = try? Temporary.makeFile(content: content)
           sut = try? ImportsAnalyzer().analyze(fileURL: self.fileURL)
         }
 

--- a/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
@@ -50,7 +50,7 @@ final class InitializerAnalyzerSpec: QuickSpec {
           let content = """
                         public final class FakeType {}
                         """
-          fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+          fileURL = try? Temporary.makeFile(content: content)
         }
 
         it("returns an empty array") {
@@ -67,7 +67,7 @@ final class InitializerAnalyzerSpec: QuickSpec {
             convenience init(someString: String, someInt: Int) {}
           }
           """
-          fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+          fileURL = try? Temporary.makeFile(content: content)
         }
 
         it("detects the type name") {
@@ -94,6 +94,29 @@ final class InitializerAnalyzerSpec: QuickSpec {
           expect(result?.first?.modifiers) == .convenience
         }
 
+        context("with default values") {
+          beforeEach {
+            let content = """
+            public final class FakeType {
+              convenience init(someString: String = "abc", someInt: Int = 2) {}
+            }
+            """
+            fileURL = try? Temporary.makeFile(content: content)
+          }
+
+          it("detects the parameters") {
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result?.first?.parameters) == [
+              InitializerStatement.Parameter(name: "someString", typeName: "String"),
+              InitializerStatement.Parameter(name: "someInt", typeName: "Int"),
+            ]
+          }
+
+          it("detects the modifier") {
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result?.first?.modifiers) == .convenience
+          }
+        }
       }
 
       context("with multiple initializers") {
@@ -108,7 +131,7 @@ final class InitializerAnalyzerSpec: QuickSpec {
             override init(someString: String, someInt: Int) {}
           }
           """
-          fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+          fileURL = try? Temporary.makeFile(content: content)
         }
 
         it("returns the correct modifiers") {

--- a/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
@@ -1,0 +1,25 @@
+// Created by Francisco Diaz on 3/27/20.
+//
+// Copyright (c) 2020 Francisco Diaz
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation

--- a/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
@@ -22,4 +22,114 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import Nimble
+import Quick
 import Foundation
+
+@testable import SwiftInspectorCore
+
+final class InitializerAnalyzerSpec: QuickSpec {
+  override func spec() {
+    var fileURL: URL!
+    var sut = InitializerAnalyzer(name: "FakeType")
+
+    beforeEach {
+      sut = InitializerAnalyzer(name: "FakeType")
+    }
+
+    afterEach {
+      guard let fileURL = fileURL else {
+        return
+      }
+      try? Temporary.removeItem(at: fileURL)
+    }
+
+    describe("analyze(fileURL:)") {
+      context("when there is no initializer") {
+        beforeEach {
+          let content = """
+                        public final class FakeType {}
+                        """
+          fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+        }
+
+        it("returns an empty array") {
+          let result = try? sut.analyze(fileURL: fileURL)
+
+          expect(result).to(beEmpty())
+        }
+      }
+
+      context("when there is an initializer") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            convenience init(someString: String, someInt: Int) {}
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+        }
+
+        it("detects the type name") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.first?.typeName) == "FakeType"
+        }
+
+        it("returns an empty array if the type name is not present") {
+          let sut = InitializerAnalyzer(name: "AnotherType")
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result).to(beEmpty())
+        }
+
+        it("detects the parameters") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.first?.parameters) == [
+            InitializerStatement.Parameter(name: "someString", typeName: "String"),
+            InitializerStatement.Parameter(name: "someInt", typeName: "Int"),
+          ]
+        }
+
+        it("detects the modifier") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.first?.modifiers) == .convenience
+        }
+
+      }
+
+      context("with multiple initializers") {
+        beforeEach {
+          let content = """
+          public struct AnotherType {
+            init(fooBar: String)
+          }
+
+          public final class FakeType {
+            init(someString: String) {}
+            override init(someString: String, someInt: Int) {}
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content, name: "ABC")
+        }
+
+        it("returns the correct modifiers") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.first?.modifiers) == .designated
+          expect(result?.last?.modifiers) == [.override, .designated]
+        }
+
+        it("returns the correct parameters") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.first?.parameters) == [
+            InitializerStatement.Parameter(name: "someString", typeName: "String"),
+          ]
+
+          expect(result?.last?.parameters) == [
+            InitializerStatement.Parameter(name: "someString", typeName: "String"),
+            InitializerStatement.Parameter(name: "someInt", typeName: "Int"),
+          ]
+        }
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
Adds a command to find the initializer arguments given a type name.

```
OVERVIEW: Finds information about the initializers of the specified type

USAGE: SwiftInspector initializer --path <path> --name <name> [--enable-type-only] [--disable-type-only]

OPTIONS:
  --path <path>           The absolute path to the file to inspect 
  --name <name>           The name of the type to look information of the
                          initializer 
  -t, --enable-type-only/--disable-type-only
                          The granularity of the output (default: true)
        Outputs a list of the type names by default. If disabled it outputs the
        name of the parameter and the name of the type (e.g. 'foo,Int
        bar,String')
  -h, --help              Show help information.

```