### PR TITLE
Handle the case where an initializer has a composition of types

### DIFF
--- a/Sources/SwiftInspectorCommands/InitializerCommand.swift
+++ b/Sources/SwiftInspectorCommands/InitializerCommand.swift
@@ -71,9 +71,9 @@ final class InitializerCommand: ParsableCommand {
 
   private func outputString(from statement: InitializerStatement) -> String {
     if typeOnly {
-      return statement.parameters.map { $0.typeName }.joined(separator: " ")
+      return statement.parameters.map { $0.typeNames.joined(separator: " ") }.joined(separator: " ")
     } else {
-      return statement.parameters.map { "\($0.name),\($0.typeName)" }.joined(separator: " ")
+      return statement.parameters.map { "\($0.name),\($0.typeNames.joined(separator: ","))" }.joined(separator: " ")
     }
   }
 }

--- a/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
@@ -117,6 +117,28 @@ final class InitializerAnalyzerSpec: QuickSpec {
             expect(result?.first?.modifiers) == .convenience
           }
         }
+
+        context("with a composition of types") {
+          beforeEach {
+            let content = """
+            protocol Some {}
+            protocol Another {}
+
+            public final class FakeType {
+              init(someString: Some & Another, someInt: Int) {}
+            }
+            """
+            fileURL = try? Temporary.makeFile(content: content)
+          }
+
+          it("returns all the types in the array") {
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result?.first?.parameters) == [
+              InitializerStatement.Parameter(name: "someString", typeNames: ["Some", "Another"]),
+              InitializerStatement.Parameter(name: "someInt", typeName: "Int"),
+            ]
+          }
+        }
       }
 
       context("with multiple initializers") {


### PR DESCRIPTION
Work on https://github.com/fdiaz/SwiftInspector/issues/20

This fixes an edge case of when an initializer argument contains a composition of elements.