### PR TITLE
Add a way to filter the initializer by argument names

### DIFF
--- a/Sources/SwiftInspectorCommands/InitializerCommand.swift
+++ b/Sources/SwiftInspectorCommands/InitializerCommand.swift
@@ -80,7 +80,7 @@ final class InitializerCommand: ParsableCommand {
     }
   }
 
-  /// Filters the provided `InitializerStatement` given the user provided `argumentName`
+  /// Filters the provided `InitializerStatement` given the user-provided `argumentName`
   ///
   /// - Returns: `true` if the provided initializer statement should be used as output, `false` otherwise
   private func shouldReturnParameters(from statement: InitializerStatement) -> Bool {

--- a/Sources/SwiftInspectorCommands/InitializerCommand.swift
+++ b/Sources/SwiftInspectorCommands/InitializerCommand.swift
@@ -42,7 +42,7 @@ final class InitializerCommand: ParsableCommand {
   var typeOnly: Bool
 
   @Option(parsing: .upToNextOption, help: argumentNameHelp)
-  var argumentName: [String]
+  var parameterName: [String]
 
   /// Runs the command
   func run() throws {
@@ -84,13 +84,13 @@ final class InitializerCommand: ParsableCommand {
   ///
   /// - Returns: `true` if the provided initializer statement should be used as output, `false` otherwise
   private func shouldReturnParameters(from statement: InitializerStatement) -> Bool {
-    guard !argumentName.isEmpty else {
+    guard !parameterName.isEmpty else {
       return true
     }
 
     let parameterNames = statement.parameters.map { $0.name }
 
-    return parameterNames.sorted().elementsEqual(argumentName.sorted())
+    return parameterNames.sorted().elementsEqual(parameterName.sorted())
   }
 }
 
@@ -99,7 +99,7 @@ private var typeOnlyHelp = ArgumentHelp("The granularity of the output",
                                         Outputs a list of the type names by default. If disabled it outputs the name of the parameter and the name of the type (e.g. 'foo,Int bar,String')
                                         """)
 
-private var argumentNameHelp = ArgumentHelp("A list of arguments name to filter initializers for",
+private var argumentNameHelp = ArgumentHelp("A list of parameter names to filter initializers for",
                                         discussion: """
-                                        When this value is provided, the command will only return the initializers that contain the list of arguments provided and will filter out everything else
+                                        When this value is provided, the command will only return the initializers that contain the list of parameters provided and will filter out everything else
                                         """)

--- a/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
@@ -87,6 +87,33 @@ final class InitializerCommandSpec: QuickSpec {
         }
       }
 
+      context("when argument-name is passed") {
+        var fileURL: URL!
+
+        beforeEach {
+          fileURL = try? Temporary.makeFile(content: """
+          final class Some {
+            init(some: String, someInt: Int) {}
+          }
+          """)
+        }
+
+        it("filters out the initializers that don't have the argument names") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--argument-name", "AnotherType"])
+          expect(result?.outputMessage).toNot(contain("String"))
+        }
+
+        it("returns the initializers that have the same names") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--argument-name", "some", "someInt"])
+          expect(result?.outputMessage).to(contain("String Int"))
+        }
+
+        it("returns the initializers that have the same names in different order") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--argument-name", "someInt", "some"])
+          expect(result?.outputMessage).to(contain("String Int"))
+        }
+      }
+
     }
   }
 }

--- a/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/InitializerCommandSpec.swift
@@ -87,7 +87,7 @@ final class InitializerCommandSpec: QuickSpec {
         }
       }
 
-      context("when argument-name is passed") {
+      context("when parameter-name is passed") {
         var fileURL: URL!
 
         beforeEach {
@@ -98,18 +98,18 @@ final class InitializerCommandSpec: QuickSpec {
           """)
         }
 
-        it("filters out the initializers that don't have the argument names") {
-          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--argument-name", "AnotherType"])
+        it("filters out the initializers that don't have the parameter names") {
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--parameter-name", "AnotherType"])
           expect(result?.outputMessage).toNot(contain("String"))
         }
 
         it("returns the initializers that have the same names") {
-          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--argument-name", "some", "someInt"])
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--parameter-name", "some", "someInt"])
           expect(result?.outputMessage).to(contain("String Int"))
         }
 
         it("returns the initializers that have the same names in different order") {
-          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--argument-name", "someInt", "some"])
+          let result = try? TestTask.run(withArguments: ["initializer", "--path", fileURL.path, "--name", "Some", "--parameter-name", "someInt", "some"])
           expect(result?.outputMessage).to(contain("String Int"))
         }
       }

--- a/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/InitializerAnalyzerSpec.swift
@@ -139,6 +139,43 @@ final class InitializerAnalyzerSpec: QuickSpec {
             ]
           }
         }
+
+        context("with a tuple") {
+          beforeEach {
+            let content = """
+            public final class FakeType {
+              init(someTyple: (String, Int)) {}
+            }
+            """
+            fileURL = try? Temporary.makeFile(content: content)
+          }
+
+          it("returns all the types in the array") {
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result?.first?.parameters) == [
+              InitializerStatement.Parameter(name: "someTyple", typeNames: ["String", "Int"]),
+            ]
+          }
+        }
+
+        context("with a closure") {
+          beforeEach {
+            let content = """
+            public final class FakeType {
+              init(someTyple: (String, Int)) {}
+            }
+            """
+            fileURL = try? Temporary.makeFile(content: content)
+          }
+
+          it("returns all the types in the array") {
+            let result = try? sut.analyze(fileURL: fileURL)
+            expect(result?.first?.parameters) == [
+              InitializerStatement.Parameter(name: "someTyple", typeNames: ["String", "Int"]),
+            ]
+          }
+        }
+
       }
 
       context("with multiple initializers") {


### PR DESCRIPTION
Fixes https://github.com/fdiaz/SwiftInspector/issues/20

This adds a way to filter the initializer command given a list of argument names