### PR TITLE
Add Makefile to simplify setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+prefix ?= /usr/local
+bindir ?= $(prefix)/bin
+
+.PHONY: develop
+develop:
+	swift package generate-xcodeproj
+	open SwiftInspector.xcodeproj 
+
+.PHONY: build
+build:
+	swift build -c release
+
+.PHONY: install
+install:
+	build
+	mv ".build/release/SwiftInspector" ".build/release/swift-inspector" 
+	install ".build/release/swift-inspector" "$(bindir)"
+
+.PHONY: uninstall
+uninstall:
+	rm -rf "$(bindir)/swift-inspector"
+
+.PHONY: clean
+clean:
+	rm -rf .build

--- a/README.md
+++ b/README.md
@@ -12,19 +12,28 @@ This project is currently under development and can have breaking API changes.
 
 ---
 
-## Generating an Xcode Project
+## Requirements
 
-To see this project locally in Xcode you can run the following command on the root of this project:
-`swift package generate-xcodeproj`
+- Swift 5.1
 
-This will generate an `SwiftInspector.xcodeproj` in the root of this repository.
+## Install
 
-## Run this project
+Run the following command:
 
-Open the generated Xcode project:
+```
+$ git clone git@github.com:fdiaz/SwiftInspector.git
+$ cd SwiftInspector
+$ make install
+```
 
-`open SwiftInspector.xcodeproj`
+## Develop
 
-Then run the project using ⌘ R. 
+If you want to contribute to this project, please take a look at our [CONTRIBUTING](CONTRIBUTING.md) guidelines. To generate and open the project in Xcode run:
 
-Make sure to select "My Mac" as the device.
+```
+$ make develop
+```
+
+## License
+
+[MIT](LICENSE)


### PR DESCRIPTION
Heavily inspired by [this article](https://nshipster.com/homebrew/#creating-a-makefile) I decided to simplify the installation and development of SwiftInspector.

We might want to put this in Homebrew at some point, but not today.