### PR TITLE
Update swift 5.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
     # Checks-out the repo. More at: https://github.com/actions/checkout
     - uses: actions/checkout@v2
+    - name: Select Xcode version
+      run: sudo xcode-select -switch /Applications/Xcode_11.4.app
     - name: Build project
       run: swift build
     - name: Run tests and gather code coverage

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "3e3eb191fcdbecc6031522660c4ed6ce25282c25",
-          "version": "0.50100.0"
+          "revision": "0688b9cfc4c3dd234e4f55f1f056b2affc849873",
+          "version": "0.50200.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser",
         "state": {
           "branch": null,
-          "revision": "f6ac7b8118ff5d1bc0faee7f37bf6f8fd8f95602",
-          "version": "0.0.1"
+          "revision": "8d31a0905c346a45c87773ad50862b5b3df8dff6",
+          "version": "0.0.4"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     .library(name: "SwiftInspectorCore", targets: ["SwiftInspectorCore"])
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.4")),
     .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")),
     .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.1")),
     .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "2.0.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.4")),
-    .package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")),
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")),
     .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.1")),
     .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "2.0.0")),
   ],

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is currently under development and can have breaking API changes.
 
 ## Requirements
 
-- Swift 5.1
+- Swift 5.2
 
 ## Install
 

--- a/Sources/SwiftInspectorCore/ImportsAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/ImportsAnalyzer.swift
@@ -97,7 +97,7 @@ public final class ImportsAnalyzer: Analyzer {
     var submoduleIdentifier: String = ""
 
     for child in syntaxNode.children {
-      guard let accessPath = child as? AccessPathSyntax else {
+      guard let accessPath = child.as(AccessPathSyntax.self) else {
         continue
       }
 
@@ -118,7 +118,7 @@ public final class ImportsAnalyzer: Analyzer {
 
   private func findAttribute(from syntaxNode: ImportDeclSyntax) -> String {
     for child in syntaxNode.children {
-      guard let attributeList = child as? AttributeListSyntax else {
+      guard let attributeList = child.as(AttributeListSyntax.self) else {
         continue
       }
 

--- a/Sources/SwiftInspectorCore/StaticUsageAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/StaticUsageAnalyzer.swift
@@ -52,7 +52,7 @@ public final class StaticUsageAnalyzer: Analyzer {
     // A MemberAccessExprSyntax contains a base, a dot and a name.
     // The base in this case will be the type of the staticMember, while the name is the member
 
-    let baseNode = node.base as? IdentifierExprSyntax
+    let baseNode = node.base?.as(IdentifierExprSyntax.self)
     let nameText = node.name.text
     guard let baseText = baseNode?.identifier.text else {
       return false

--- a/Sources/SwiftInspectorCore/TypealiasAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypealiasAnalyzer.swift
@@ -53,7 +53,7 @@ public final class TypealiasAnalyzer: Analyzer {
     var identifiers: [String] = []
 
     for child in node.children {
-      guard let typeInitializerSyntax = child as? TypeInitializerClauseSyntax else {
+      guard let typeInitializerSyntax = child.as(TypeInitializerClauseSyntax.self) else {
         continue
       }
 


### PR DESCRIPTION
Updates `ArgumentParser` and `SwiftSyntax` to be able to be used in Swift 5.2