### PR TITLE
Add a way to return the conforming type when searching for type conformance

### DIFF
--- a/Sources/SwiftInspectorCommands/Tests/TypeConformanceCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TypeConformanceCommandSpec.swift
@@ -79,7 +79,7 @@ final class TypeConformanceCommandSpec: QuickSpec {
           var path: String!
 
           beforeEach {
-            fileURL = try? Temporary.makeFile(content: "final class Some: SomeType { }")
+            fileURL = try? Temporary.makeFile(content: "final class Foo: SomeType { }")
             path = fileURL?.path ?? ""
           }
 
@@ -108,6 +108,11 @@ final class TypeConformanceCommandSpec: QuickSpec {
             it("outputs the path of the file") {
               let result = try? TestTask.run(withArguments: ["type-conformance", "--type-names", "SomeType", "--path", path])
               expect(result?.outputMessage).to(contain(fileURL.lastPathComponent))
+            }
+
+            it("outputs the conforming type name") {
+              let result = try? TestTask.run(withArguments: ["type-conformance", "--type-names", "SomeType", "--path", path])
+              expect(result?.outputMessage).to(contain("Foo"))
             }
           }
 

--- a/Sources/SwiftInspectorCommands/TypeConformanceCommand.swift
+++ b/Sources/SwiftInspectorCommands/TypeConformanceCommand.swift
@@ -68,7 +68,14 @@ final class TypeConformanceCommand: ParsableCommand {
 
   // Output to standard output
   private func output(from conformance: TypeConformance) {
-    print("\(path) \(conformance.typeName) \(conformance.doesConform)")
+    guard !conformance.conformingTypeNames.isEmpty else {
+      print("\(path) \(conformance.typeName) \(conformance.doesConform)")
+      return
+    }
+
+    conformance.conformingTypeNames.forEach {
+      print("\(path) \(conformance.typeName) \(conformance.doesConform) \($0)")
+    }
   }
 
 }

--- a/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
@@ -40,7 +40,7 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
     }
     
     describe("analyze(fileURL:)") {
-      var result: TypeConformance!
+      var result: TypeConformance?
       
       context("when a type conforms to a protocol") {
         context("with only one conformance") {

--- a/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
@@ -76,7 +76,7 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
               """
 
               self.fileURL = try? Temporary.makeFile(content: content)
-              let sut = TypeConformanceAnalyzer(typeName: "Bar")
+              let sut = TypeConformanceAnalyzer(typeName: "Foo")
               result = try? sut.analyze(fileURL: self.fileURL)
             }
 

--- a/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
@@ -40,10 +40,11 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
     }
 
     describe("analyze(fileURL:)") {
+      var result: TypeConformance!
 
       context("when a type conforms to a protocol") {
         context("with only one conformance") {
-          it("conforms") {
+          beforeEach {
             let content = """
             protocol Some {}
 
@@ -51,15 +52,16 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
             """
 
             self.fileURL = try? Temporary.makeFile(content: content)
-
             let sut = TypeConformanceAnalyzer(typeName: "Some")
-            let result = try? sut.analyze(fileURL: self.fileURL)
+            result = try? sut.analyze(fileURL: self.fileURL)
+          }
 
+          it("conforms") {
             expect(result?.doesConform) == true
           }
 
           context("when the type has multiple conformances") {
-            it("conforms") {
+            beforeEach {
               let content = """
               protocol Foo {}
               protocol Bar {}
@@ -70,16 +72,17 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
               """
 
               self.fileURL = try? Temporary.makeFile(content: content)
-
               let sut = TypeConformanceAnalyzer(typeName: "Bar")
-              let result = try? sut.analyze(fileURL: self.fileURL)
+              result = try? sut.analyze(fileURL: self.fileURL)
+            }
 
+            it("conforms") {
               expect(result?.doesConform) == true
             }
           }
 
           context("when the types conform in a different line") {
-            it("conforms") {
+            beforeEach {
               let content = """
               protocol A {}
               protocol B {}
@@ -90,19 +93,19 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
               """
 
               self.fileURL = try? Temporary.makeFile(content: content)
-
               let sut = TypeConformanceAnalyzer(typeName: "B")
-              let result = try? sut.analyze(fileURL: self.fileURL)
+              result = try? sut.analyze(fileURL: self.fileURL)
+            }
 
+            it("conforms") {
               expect(result?.doesConform) == true
             }
           }
-
         }
       }
 
       context("when a type implements a subclass") {
-        it("is marked as conforms") {
+        beforeEach {
           let content = """
           open class Some {}
 
@@ -110,16 +113,17 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
           """
 
           self.fileURL = try? Temporary.makeFile(content: content)
-
           let sut = TypeConformanceAnalyzer(typeName: "Some")
-          let result = try? sut.analyze(fileURL: self.fileURL)
+          result = try? sut.analyze(fileURL: self.fileURL)
+        }
 
+        it("is marked as conforms") {
           expect(result?.doesConform) == true
         }
       }
 
       context("when the type is not present") {
-        it("is not marked as conforms") {
+        beforeEach {
           let content = """
           protocol Some {}
 
@@ -127,10 +131,11 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
           """
 
           self.fileURL = try? Temporary.makeFile(content: content)
-
           let sut = TypeConformanceAnalyzer(typeName: "AnotherType")
-          let result = try? sut.analyze(fileURL: self.fileURL)
+          result = try? sut.analyze(fileURL: self.fileURL)
+        }
 
+        it("is not marked as conforms") {
           expect(result?.doesConform) == false
         }
       }

--- a/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
@@ -64,7 +64,51 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
             expect(result?.conformingTypeNames) == ["Another"]
           }
         }
+
+        context("with a struct conforming to the protocol") {
+          beforeEach {
+            let content = """
+            protocol Some {}
+
+            struct Another: Some {}
+            """
+
+            self.fileURL = try? Temporary.makeFile(content: content)
+            let sut = TypeConformanceAnalyzer(typeName: "Some")
+            result = try? sut.analyze(fileURL: self.fileURL)
+          }
+
+          it("conforms") {
+            expect(result?.doesConform) == true
+          }
+
+          it("returns the conforming type name") {
+            expect(result?.conformingTypeNames) == ["Another"]
+          }
+        }
         
+        context("with an enum conforming to the protocol") {
+          beforeEach {
+            let content = """
+            protocol Some {}
+
+            enum Another: Some {}
+            """
+
+            self.fileURL = try? Temporary.makeFile(content: content)
+            let sut = TypeConformanceAnalyzer(typeName: "Some")
+            result = try? sut.analyze(fileURL: self.fileURL)
+          }
+
+          it("conforms") {
+            expect(result?.doesConform) == true
+          }
+
+          it("returns the conforming type name") {
+            expect(result?.conformingTypeNames) == ["Another"]
+          }
+        }
+
         context("when the type has multiple conformances") {
           beforeEach {
             let content = """

--- a/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
@@ -60,6 +60,10 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
             expect(result?.doesConform) == true
           }
 
+          it("returns the conforming type name") {
+            expect(result?.conformingTypeNames) == ["Another"]
+          }
+
           context("when the type has multiple conformances") {
             beforeEach {
               let content = """
@@ -78,6 +82,10 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
 
             it("conforms") {
               expect(result?.doesConform) == true
+            }
+
+            it("returns the conforming type names") {
+              expect(result?.conformingTypeNames) == ["Another", "Second"]
             }
           }
 
@@ -100,6 +108,10 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
             it("conforms") {
               expect(result?.doesConform) == true
             }
+
+            it("returns the conforming type name") {
+              expect(result?.conformingTypeNames) == ["Another"]
+            }
           }
         }
       }
@@ -120,6 +132,10 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
         it("is marked as conforms") {
           expect(result?.doesConform) == true
         }
+
+        it("returns the conforming type name") {
+          expect(result?.conformingTypeNames) == ["Another"]
+        }
       }
 
       context("when the type is not present") {
@@ -137,6 +153,10 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
 
         it("is not marked as conforms") {
           expect(result?.doesConform) == false
+        }
+
+        it("returns an empty array for conforming types") {
+          expect(result?.conformingTypeNames) == []
         }
       }
 

--- a/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypeConformanceAnalyzerSpec.swift
@@ -30,7 +30,7 @@ import Foundation
 
 final class TypeConformanceAnalyzerSpec: QuickSpec {
   private var fileURL: URL!
-
+  
   override func spec() {
     afterEach {
       guard let fileURL = self.fileURL else {
@@ -38,10 +38,10 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
       }
       try? Temporary.removeItem(at: fileURL)
     }
-
+    
     describe("analyze(fileURL:)") {
       var result: TypeConformance!
-
+      
       context("when a type conforms to a protocol") {
         context("with only one conformance") {
           beforeEach {
@@ -50,23 +50,24 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
 
             class Another: Some {}
             """
-
+            
             self.fileURL = try? Temporary.makeFile(content: content)
             let sut = TypeConformanceAnalyzer(typeName: "Some")
             result = try? sut.analyze(fileURL: self.fileURL)
           }
-
+          
           it("conforms") {
             expect(result?.doesConform) == true
           }
-
+          
           it("returns the conforming type name") {
             expect(result?.conformingTypeNames) == ["Another"]
           }
-
-          context("when the type has multiple conformances") {
-            beforeEach {
-              let content = """
+        }
+        
+        context("when the type has multiple conformances") {
+          beforeEach {
+            let content = """
               protocol Foo {}
               protocol Bar {}
 
@@ -74,24 +75,24 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
 
               class Second: Foo {}
               """
-
-              self.fileURL = try? Temporary.makeFile(content: content)
-              let sut = TypeConformanceAnalyzer(typeName: "Foo")
-              result = try? sut.analyze(fileURL: self.fileURL)
-            }
-
-            it("conforms") {
-              expect(result?.doesConform) == true
-            }
-
-            it("returns the conforming type names") {
-              expect(result?.conformingTypeNames) == ["Another", "Second"]
-            }
+            
+            self.fileURL = try? Temporary.makeFile(content: content)
+            let sut = TypeConformanceAnalyzer(typeName: "Foo")
+            result = try? sut.analyze(fileURL: self.fileURL)
           }
-
-          context("when the types conform in a different line") {
-            beforeEach {
-              let content = """
+          
+          it("conforms") {
+            expect(result?.doesConform) == true
+          }
+          
+          it("returns the conforming type names") {
+            expect(result?.conformingTypeNames) == ["Another", "Second"]
+          }
+        }
+        
+        context("when the types conform in a different line") {
+          beforeEach {
+            let content = """
               protocol A {}
               protocol B {}
               protocol C {}
@@ -99,23 +100,22 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
               class Another: A
               ,B, C  {}
               """
-
-              self.fileURL = try? Temporary.makeFile(content: content)
-              let sut = TypeConformanceAnalyzer(typeName: "B")
-              result = try? sut.analyze(fileURL: self.fileURL)
-            }
-
-            it("conforms") {
-              expect(result?.doesConform) == true
-            }
-
-            it("returns the conforming type name") {
-              expect(result?.conformingTypeNames) == ["Another"]
-            }
+            
+            self.fileURL = try? Temporary.makeFile(content: content)
+            let sut = TypeConformanceAnalyzer(typeName: "B")
+            result = try? sut.analyze(fileURL: self.fileURL)
+          }
+          
+          it("conforms") {
+            expect(result?.doesConform) == true
+          }
+          
+          it("returns the conforming type name") {
+            expect(result?.conformingTypeNames) == ["Another"]
           }
         }
       }
-
+      
       context("when a type implements a subclass") {
         beforeEach {
           let content = """
@@ -123,21 +123,21 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
 
           class Another: Some {}
           """
-
+          
           self.fileURL = try? Temporary.makeFile(content: content)
           let sut = TypeConformanceAnalyzer(typeName: "Some")
           result = try? sut.analyze(fileURL: self.fileURL)
         }
-
+        
         it("is marked as conforms") {
           expect(result?.doesConform) == true
         }
-
+        
         it("returns the conforming type name") {
           expect(result?.conformingTypeNames) == ["Another"]
         }
       }
-
+      
       context("when the type is not present") {
         beforeEach {
           let content = """
@@ -145,22 +145,22 @@ final class TypeConformanceAnalyzerSpec: QuickSpec {
 
           class Another: Some {}
           """
-
+          
           self.fileURL = try? Temporary.makeFile(content: content)
           let sut = TypeConformanceAnalyzer(typeName: "AnotherType")
           result = try? sut.analyze(fileURL: self.fileURL)
         }
-
+        
         it("is not marked as conforms") {
           expect(result?.doesConform) == false
         }
-
+        
         it("returns an empty array for conforming types") {
           expect(result?.conformingTypeNames) == []
         }
       }
-
+      
     }
   }
-
+  
 }

--- a/Sources/SwiftInspectorCore/TypeConformanceAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeConformanceAnalyzer.swift
@@ -46,7 +46,7 @@ public final class TypeConformanceAnalyzer: Analyzer {
 
     reader.walk(syntax)
 
-    return TypeConformance(typeName: typeName, doesConform: doesConform, conformingTypeName: "")
+    return TypeConformance(typeName: typeName, doesConform: doesConform, conformingTypeNames: [])
   }
 
   // MARK: Private
@@ -64,7 +64,7 @@ public final class TypeConformanceAnalyzer: Analyzer {
 public struct TypeConformance: Equatable {
   public let typeName: String
   public let doesConform: Bool
-  public let conformingTypeName: String
+  public let conformingTypeNames: [String]
 }
 
 private final class TypeConformanceSyntaxVisitor: SyntaxVisitor {

--- a/Sources/SwiftInspectorCore/TypeConformanceAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/TypeConformanceAnalyzer.swift
@@ -46,7 +46,7 @@ public final class TypeConformanceAnalyzer: Analyzer {
 
     reader.walk(syntax)
 
-    return TypeConformance(typeName: typeName, doesConform: doesConform)
+    return TypeConformance(typeName: typeName, doesConform: doesConform, conformingTypeName: "")
   }
 
   // MARK: Private
@@ -64,6 +64,7 @@ public final class TypeConformanceAnalyzer: Analyzer {
 public struct TypeConformance: Equatable {
   public let typeName: String
   public let doesConform: Bool
+  public let conformingTypeName: String
 }
 
 private final class TypeConformanceSyntaxVisitor: SyntaxVisitor {


### PR DESCRIPTION
**This PR is easier to review commit-by-commit**

The type-conformance command didn't return the information of the conforming type, only if the conformance existed in the file or not.

This PR introduces a way to output the names of the conforming types too.

That is, when a file contains:

```swift
protocol Some {}

final class Foo: Some { }
```

We now also return `Foo` in the output.