### PR TITLE
Fix dependency on build from install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,7 @@ build:
 	swift build -c release
 
 .PHONY: install
-install:
-	build
+install: build
 	mv ".build/release/SwiftInspector" ".build/release/swift-inspector" 
 	install ".build/release/swift-inspector" "$(bindir)"
 


### PR DESCRIPTION
This was failing with 

```
➜  make install
build
make: build: No such file or directory
make: *** [install] Error 1
```

This fixes that by making the `install` call the `build` defined above in this Makefile before executing the rest of the commands, while before it was just trying to execute an inexistent `build` command.