### PR TITLE
add property analyzer

### DIFF
--- a/Sources/SwiftInspectorCommands/InspectorCommand.swift
+++ b/Sources/SwiftInspectorCommands/InspectorCommand.swift
@@ -33,6 +33,7 @@ public struct InspectorCommand: ParsableCommand {
     subcommands: [
       ImportsCommand.self,
       InitializerCommand.self,
+      PropertyAnalyzerCommand.self,
       StaticUsageCommand.self,
       TypealiasCommand.self,
       TypeConformanceCommand.self,

--- a/Sources/SwiftInspectorCommands/PropertyAnalyzerCommand.swift
+++ b/Sources/SwiftInspectorCommands/PropertyAnalyzerCommand.swift
@@ -1,0 +1,76 @@
+// Created by Tyler Hedrick on 8/17/20.
+//
+// Copyright (c) 2020 Tyler Hedrick
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import ArgumentParser
+import Foundation
+import SwiftInspectorCore
+
+final class PropertyAnalyzerCommand: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "properties",
+    abstract: "Finds property information for the provided type"
+  )
+
+  @Option(help: nameArgumentHelp)
+  var name: String
+
+  @Option(help: "The absolute path of the file to inspect")
+  var path: String
+
+  /// Runs the command
+  func run() throws {
+    let cachedSyntaxTree = CachedSyntaxTree()
+
+    let analyzer = PropertyAnalyzer(typeName: name, cachedSyntaxTree: cachedSyntaxTree)
+    let fileURL = URL(fileURLWithPath: path)
+    if let propertyInformation = try analyzer.analyze(fileURL: fileURL) {
+      print(outputString(from: propertyInformation))
+    }
+  }
+
+  /// Validates if the arguments of this command are valid
+  func validate() throws {
+    guard !name.isEmpty else {
+      throw InspectorError.emptyArgument(argumentName: "--name")
+    }
+    guard !path.isEmpty else {
+      throw InspectorError.emptyArgument(argumentName: "--path")
+    }
+    let pathURL = URL(fileURLWithPath: path)
+    guard FileManager.default.isSwiftFile(at: pathURL) else {
+      throw InspectorError.invalidArgument(argumentName: "--path", value: path)
+    }
+  }
+
+  private func outputString(from statement: TypeWithPropInfo) -> String {
+    let propString = statement.properties.map { propInfo in
+      "(\(propInfo.name)|\(propInfo.access)|\(propInfo.scope))"
+    }.joined(separator: ",")
+    return "\(statement.name):\(propString)"
+  }
+}
+
+private let nameArgumentHelp = ArgumentHelp(
+  "The name of the type to find property information on",
+  discussion: "This may be a enum, class, struct, or protocol.")

--- a/Sources/SwiftInspectorCommands/PropertyAnalyzerCommand.swift
+++ b/Sources/SwiftInspectorCommands/PropertyAnalyzerCommand.swift
@@ -65,7 +65,7 @@ final class PropertyAnalyzerCommand: ParsableCommand {
 
   private func outputString(from statement: TypeProperties) -> String {
     statement.properties.map { propInfo in
-      "\(propInfo.name),\(propInfo.modifiers)"
+      "\(statement.name),\(propInfo.name),\(propInfo.modifiers)"
     }.joined(separator: "\n")
   }
 }
@@ -73,3 +73,24 @@ final class PropertyAnalyzerCommand: ParsableCommand {
 private let nameArgumentHelp = ArgumentHelp(
   "The name of the type to find property information on",
   discussion: "This may be a enum, class, struct, or protocol.")
+
+extension TypeProperties.Modifier: CustomStringConvertible, CustomDebugStringConvertible {
+  public var description: String {
+    var outputValues: [String] = []
+    // Order is important here! Access control modifiers should always go before scope modifiers
+    // Access control modifiers
+    if contains(.public) { outputValues.append("public") }
+    if contains(.private) { outputValues.append("private") }
+    if contains(.fileprivate) { outputValues.append("fileprivate") }
+    if contains(.internal) { outputValues.append("internal") }
+    if contains(.privateSet) { outputValues.append("private(set)") }
+    if contains(.internalSet) { outputValues.append("internal(set)") }
+    if contains(.publicSet) { outputValues.append("public(set)") }
+    // Scope modifiers
+    if contains(.static) { outputValues.append("static") }
+    if contains(.instance) { outputValues.append("instance") }
+    return outputValues.joined(separator: ",")
+  }
+
+  public var debugDescription: String { description }
+}

--- a/Sources/SwiftInspectorCommands/PropertyAnalyzerCommand.swift
+++ b/Sources/SwiftInspectorCommands/PropertyAnalyzerCommand.swift
@@ -65,7 +65,7 @@ final class PropertyAnalyzerCommand: ParsableCommand {
 
   private func outputString(from statement: TypeProperties) -> String {
     statement.properties.map { propInfo in
-      "\(propInfo.name),\(propInfo.modifier)"
+      "\(propInfo.name),\(propInfo.modifiers)"
     }.joined(separator: "\n")
   }
 }

--- a/Sources/SwiftInspectorCommands/PropertyAnalyzerCommand.swift
+++ b/Sources/SwiftInspectorCommands/PropertyAnalyzerCommand.swift
@@ -63,11 +63,10 @@ final class PropertyAnalyzerCommand: ParsableCommand {
     }
   }
 
-  private func outputString(from statement: TypeWithPropInfo) -> String {
-    let propString = statement.properties.map { propInfo in
-      "(\(propInfo.name)|\(propInfo.access)|\(propInfo.scope))"
-    }.joined(separator: ",")
-    return "\(statement.name):\(propString)"
+  private func outputString(from statement: TypeProperties) -> String {
+    statement.properties.map { propInfo in
+      "\(propInfo.name),\(propInfo.modifier)"
+    }.joined(separator: "\n")
   }
 }
 

--- a/Sources/SwiftInspectorCommands/Tests/PropertyAnalyzerCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/PropertyAnalyzerCommandSpec.swift
@@ -1,0 +1,106 @@
+// Created by Tyler Hedrick on 8/17/20.
+//
+// Copyright (c) 2020 Tyler Hedrick
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Nimble
+import Quick
+import Foundation
+
+@testable import SwiftInspectorCore
+
+final class PropertyAnalyzerCommandSpec: QuickSpec {
+  override func spec() {
+    describe("run") {
+
+      context("with no arguments") {
+        it("fails") {
+          let result = try? TestTask.run(withArguments: ["properties"])
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("when path is invalid") {
+        it("fails when empty") {
+          let result = try? TestTask.run(withArguments: ["properties", "--path", ""])
+          expect(result?.didFail) == true
+        }
+
+        it("fails when not provided") {
+          let result = try? TestTask.run(withArguments: ["properties", "--path"])
+          expect(result?.didFail) == true
+        }
+
+        it("fails when it doesn't exist") {
+          let result = try? TestTask.run(withArguments: ["properties", "--path", "/fake/path"])
+          expect(result?.didFail) == true
+        }
+
+        it("fails when name is present but the file is invalid") {
+          let result = try? TestTask.run(withArguments: ["properties", "--path", "/fake/path", "--name", "SomeType"])
+          expect(result?.didFail) == true
+        }
+      }
+
+      context("when name is passed") {
+        var fileURL: URL!
+
+        beforeEach {
+          fileURL = try? Temporary.makeFile(content: """
+          final class Some {
+            public var thing: String = "Hello, World"
+          }
+          """)
+        }
+
+        afterEach {
+          try? Temporary.removeItem(at: fileURL)
+        }
+
+        it("fails when name is empty") {
+          let result = try? TestTask.run(withArguments: ["properties", "--path", fileURL.path, "--name", ""])
+          expect(result?.didFail) == true
+        }
+
+        it("fails when name is not provided") {
+          let result = try? TestTask.run(withArguments: ["properties", "--path", fileURL.path, "--name"])
+          expect(result?.didFail) == true
+        }
+
+        it("fails when path is empty") {
+          let result = try? TestTask.run(withArguments: ["properties", "--name", "Some"])
+          expect(result?.didFail) == true
+        }
+
+        it("succeeds") {
+          let result = try? TestTask.run(withArguments: ["properties", "--path", fileURL.path, "--name", "Some"])
+          expect(result?.didSucceed) == true
+        }
+
+        it("returns the type name with property information including the name, access, and scope") {
+          let result = try? TestTask.run(withArguments: ["properties", "--path", fileURL.path, "--name", "Some"])
+          expect(result?.outputMessage).to(contain("Some:(thing|public|instance)"))
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwiftInspectorCommands/Tests/PropertyAnalyzerCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/PropertyAnalyzerCommandSpec.swift
@@ -98,7 +98,7 @@ final class PropertyAnalyzerCommandSpec: QuickSpec {
 
         it("returns the type name with property information including the name, access, and scope") {
           let result = try? TestTask.run(withArguments: ["properties", "--path", fileURL.path, "--name", "Some"])
-          expect(result?.outputMessage).to(contain("Some:(thing|public|instance)"))
+          expect(result?.outputMessage).to(contain("thing,public,instance"))
         }
       }
     }

--- a/Sources/SwiftInspectorCommands/Tests/PropertyAnalyzerCommandSpec.swift
+++ b/Sources/SwiftInspectorCommands/Tests/PropertyAnalyzerCommandSpec.swift
@@ -98,7 +98,7 @@ final class PropertyAnalyzerCommandSpec: QuickSpec {
 
         it("returns the type name with property information including the name, access, and scope") {
           let result = try? TestTask.run(withArguments: ["properties", "--path", fileURL.path, "--name", "Some"])
-          expect(result?.outputMessage).to(contain("thing,public,instance"))
+          expect(result?.outputMessage).to(contain("Some,thing,public,instance"))
         }
       }
     }

--- a/Sources/SwiftInspectorCore/PropertyAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/PropertyAnalyzer.swift
@@ -143,7 +143,7 @@ private final class PropertySyntaxVisitor: SyntaxVisitor {
             name: identifier.identifier.text,
             typeAnnotation: simpleTypeIdentifier.name.text,
             comment: comment(from: leadingTrivia),
-            modifier: modifier))
+            modifiers: modifier))
           return
         }
         // no type annotation was found. In this case it's much more complicated to get
@@ -156,7 +156,7 @@ private final class PropertySyntaxVisitor: SyntaxVisitor {
           name: identifier.identifier.text,
           typeAnnotation: nil,
           comment: comment(from: leadingTrivia),
-          modifier: modifier))
+          modifiers: modifier))
       }
     }
 
@@ -206,7 +206,10 @@ private final class PropertySyntaxVisitor: SyntaxVisitor {
     }
 
     // If there are no explicit modifiers, this is an internal property
-    if modifier.isEmpty {
+    if !modifier.contains(.public) &&
+      !modifier.contains(.fileprivate) &&
+      !modifier.contains(.private)
+    {
       modifier = modifier.union(.internal)
     }
 
@@ -260,7 +263,7 @@ public struct TypeProperties: Hashable {
     /// Any comments associated with the property
     public let comment: String
     /// Modifier set for this type
-    public let modifier: Modifier
+    public let modifiers: Modifier
   }
 
   /// The name of the type.

--- a/Sources/SwiftInspectorCore/PropertyAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/PropertyAnalyzer.swift
@@ -23,7 +23,7 @@
 import Foundation
 import SwiftSyntax
 
-// MARK: - TypeLocationAnalyzer
+// MARK: - PropertyAnalyzer
 
 public final class PropertyAnalyzer: Analyzer {
 
@@ -34,14 +34,14 @@ public final class PropertyAnalyzer: Analyzer {
     self.cachedSyntaxTree = cachedSyntaxTree
   }
 
-  /// Finds the location(s) of the specified type name in the Swift file
+  /// Finds property information for the provided type in the Swift file
   /// - Parameter fileURL: The fileURL where the Swift file is located
-  public func analyze(fileURL: URL) throws -> TypeWithPropInfo? {
+  public func analyze(fileURL: URL) throws -> TypeProperties? {
     let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
-    var result: TypeWithPropInfo?
-    let visitor = TypeSyntaxVisitor() { [unowned self] typeWithPropInfo in
-      guard self.typeName == typeWithPropInfo.name else { return }
-      result = try? typeWithPropInfo.merge(with: result)
+    var result: TypeProperties?
+    let visitor = TypeSyntaxVisitor(typeName: typeName) { [unowned self] typeProperties in
+      guard self.typeName == typeProperties.name else { return }
+      result = try? typeProperties.merge(with: result)
     }
     visitor.walk(syntax)
     return result
@@ -53,36 +53,48 @@ public final class PropertyAnalyzer: Analyzer {
   private let typeName: String
 }
 
-// MARK: - TypeLocationSyntaxVisitor
+// MARK: - TypeSyntaxVisitor
 
 private final class TypeSyntaxVisitor: SyntaxVisitor {
 
-  init(onNodeVisit: @escaping (_ info: TypeWithPropInfo) -> Void) {
+  init(typeName: String, onNodeVisit: @escaping (_ info: TypeProperties) -> Void) {
     self.onNodeVisit = onNodeVisit
+    self.typeName = typeName
   }
 
   override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    processNode(node, withName: node.identifier.text, members: node.members.members)
+    if node.identifier.text == typeName {
+      processNode(node, withName: node.identifier.text, members: node.members.members)
+    }
     return .visitChildren
   }
 
   override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    processNode(node, withName: node.identifier.text, members: node.members.members)
+    if node.identifier.text == typeName {
+      processNode(node, withName: node.identifier.text, members: node.members.members)
+    }
     return .visitChildren
   }
 
   override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    processNode(node, withName: node.identifier.text, members: node.members.members)
+    if node.identifier.text == typeName {
+      processNode(node, withName: node.identifier.text, members: node.members.members)
+    }
     return .visitChildren
   }
 
   override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    processNode(node, withName: node.identifier.text, members: node.members.members)
+    if node.identifier.text == typeName {
+      processNode(node, withName: node.identifier.text, members: node.members.members)
+    }
     return .visitChildren
   }
 
   override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-    if let typeIdentifier = node.extendedType.as(SimpleTypeIdentifierSyntax.self) {
+    if
+      let typeIdentifier = node.extendedType.as(SimpleTypeIdentifierSyntax.self),
+      typeIdentifier.name.text == typeName
+    {
       processNode(node, withName: typeIdentifier.name.text, members: node.members.members)
     }
     return .visitChildren
@@ -90,11 +102,12 @@ private final class TypeSyntaxVisitor: SyntaxVisitor {
 
   // MARK: Private
 
-  private let onNodeVisit: (_ info: TypeWithPropInfo) -> Void
+  private let onNodeVisit: (_ info: TypeProperties) -> Void
+  private let typeName: String
 
   private func processNode<Node>(_ node: Node, withName name: String, members: MemberDeclListSyntax) where Node: SyntaxProtocol {
-    var result = [TypeWithPropInfo.PropInfo]()
-    let propertyVisitor = PropertySyntaxVisitor(parentName: name) { info in
+    var result = [TypeProperties.PropertyData]()
+    let propertyVisitor = PropertySyntaxVisitor(typeName: name) { info in
       result.append(info)
     }
     propertyVisitor.walk(node)
@@ -106,30 +119,20 @@ private final class TypeSyntaxVisitor: SyntaxVisitor {
 
 private final class PropertySyntaxVisitor: SyntaxVisitor {
 
-  init(parentName: String, onNodeVisit: @escaping (_ info: TypeWithPropInfo.PropInfo) -> Void) {
-    self.parentName = parentName
+  init(typeName: String, onNodeVisit: @escaping (_ info: TypeProperties.PropertyData) -> Void) {
+    self.typeName = typeName
     self.onNodeVisit = onNodeVisit
   }
 
   override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
     var leadingTrivia: Trivia? = node.leadingTrivia
-    var access: TypeWithPropInfo.Access = .internal
-    var scope: TypeWithPropInfo.Scope = .instance
+    let modifier = findModifiers(from: node)
 
     node.modifiers?.forEach { modifier in
       // leading trivia is on the first modifier, or the node itself if no modifiers are present
       leadingTrivia = leadingTrivia ?? modifier.leadingTrivia
-      // This attempts to get any access information from the node's modifiers
-      if let modifierAccess = TypeWithPropInfo.Access(rawValue: modifier.name.text) {
-        access = modifierAccess
-      }
-      // this attempts to get any scope information from the node's modifiers
-      if let modifierScope = TypeWithPropInfo.Scope(rawValue: modifier.name.text) {
-        scope = modifierScope
-      }
     }
 
-    // in practice this `bindings` array only has 1 element
     node.bindings.forEach { binding in
       if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
         if
@@ -140,19 +143,20 @@ private final class PropertySyntaxVisitor: SyntaxVisitor {
             name: identifier.identifier.text,
             typeAnnotation: simpleTypeIdentifier.name.text,
             comment: comment(from: leadingTrivia),
-            access: access,
-            scope: scope))
+            modifier: modifier))
           return
         }
         // no type annotation was found. In this case it's much more complicated to get
         // the type information for a variable.
+        // e.g.:
+        // public let thing: String = "Hello" has a type annotation, String which makes this easy
+        // public let thing = "Hello" does not have a type annotation, and I don't know how to handle this case.
         // TODO: Include logic to get types of any variable declaration
         onNodeVisit(.init(
           name: identifier.identifier.text,
           typeAnnotation: nil,
           comment: comment(from: leadingTrivia),
-          access: access,
-          scope: scope))
+          modifier: modifier))
       }
     }
 
@@ -161,8 +165,8 @@ private final class PropertySyntaxVisitor: SyntaxVisitor {
 
   // MARK: Private
 
-  private let parentName: String
-  private let onNodeVisit: (_ info: TypeWithPropInfo.PropInfo) -> Void
+  private let typeName: String
+  private let onNodeVisit: (_ info: TypeProperties.PropertyData) -> Void
 
   private func comment(from trivia: Trivia?) -> String {
     guard let trivia = trivia else { return "" }
@@ -176,45 +180,96 @@ private final class PropertySyntaxVisitor: SyntaxVisitor {
       }
     }.joined(separator: "\n")
   }
+
+  private func findModifiers(from node: VariableDeclSyntax) -> TypeProperties.Modifier {
+    let modifiersString: [String] = node.children
+      .compactMap { $0.as(ModifierListSyntax.self) }
+      .reduce(into: []) { result, syntax in
+        let modifiers: [String] = syntax.children
+          .compactMap { $0.as(DeclModifierSyntax.self) }
+          .map { modifierSyntax in
+            if
+              let leftParen = modifierSyntax.detailLeftParen,
+              let detail = modifierSyntax.detail,
+              let rightParen = modifierSyntax.detailRightParen
+            {
+              return modifierSyntax.name.text + leftParen.text + detail.text + rightParen.text
+            }
+            return modifierSyntax.name.text
+        }
+        result.append(contentsOf: modifiers)
+      }
+
+    var modifier = modifiersString.reduce(TypeProperties.Modifier()) { result, stringValue in
+      let modifier = TypeProperties.Modifier(stringValue: stringValue)
+      return result.union(modifier)
+    }
+
+    // If there are no explicit modifiers, this is an internal property
+    if modifier.isEmpty {
+      modifier = modifier.union(.internal)
+    }
+
+    // If the variable isn't static, it's an instance variable
+    if !modifier.contains(.static) {
+      modifier = modifier.union(.instance)
+    }
+
+    return modifier
+  }
 }
 
-// MARK: - TypeWithPropInfo
+// MARK: - TypeProperties
 
-/// Information about a located type. Indices start with 0.
-public struct TypeWithPropInfo: Hashable {
+/// Information about a type as well as its associated properties
+public struct TypeProperties: Hashable {
 
-  public enum Access: String {
-    case `public`
-    case `internal`
-    case `private`
-    case `fileprivate`
+  public struct Modifier: Hashable, OptionSet {
+    public let rawValue: Int
+
+    public static let `internal` = Modifier(rawValue: 1 << 0)
+    public static let `public` = Modifier(rawValue: 1 << 1)
+    public static let `private` = Modifier(rawValue: 1 << 2)
+    public static let privateSet = Modifier(rawValue: 1 << 3)
+    public static let `fileprivate` = Modifier(rawValue: 1 << 4)
+    public static let `instance` = Modifier(rawValue: 1 << 5)
+    public static let `static` = Modifier(rawValue: 1 << 6)
+
+    public init(rawValue: Int)  {
+      self.rawValue = rawValue
+    }
+
+    public init(stringValue: String) {
+      switch stringValue {
+      case "public": self = .public
+      case "private": self = .private
+      case "private(set)": self = .privateSet
+      case "fileprivate": self = .fileprivate
+      case "internal": self = .internal
+      case "static": self = .static
+      default: self = []
+      }
+    }
   }
 
-  public enum Scope: String {
-    case instance
-    case `static`
-  }
-
-  public struct PropInfo: Hashable {
+  public struct PropertyData: Hashable {
     /// The name of the property
     public let name: String
     /// The Type annotation of the property if it's present
     public let typeAnnotation: String?
     /// Any comments associated with the property
     public let comment: String
-    /// Access control of this property
-    public let access: Access
-    /// Scope of this property
-    public let scope: Scope
+    /// Modifier set for this type
+    public let modifier: Modifier
   }
 
   /// The name of the type.
   public let name: String
-  /// The properites on this type
-  public let properties: [PropInfo]
+  /// The properties on this type
+  public let properties: [PropertyData]
 }
 
-extension TypeWithPropInfo {
+extension TypeProperties {
   struct MergeError: Error, CustomStringConvertible {
 
     init(errorMessage: String) {
@@ -227,22 +282,40 @@ extension TypeWithPropInfo {
   }
 }
 
-extension TypeWithPropInfo.MergeError {
-  static var invalidNames = TypeWithPropInfo.MergeError(
+extension TypeProperties.MergeError {
+  static var invalidNames = TypeProperties.MergeError(
     errorMessage: "Invalid types - the type names must match to be merged.")
 }
 
-extension TypeWithPropInfo {
-  func merge(with other: TypeWithPropInfo?) throws -> TypeWithPropInfo {
+extension TypeProperties {
+  func merge(with other: TypeProperties?) throws -> TypeProperties {
     guard let other = other else {
       return self
     }
     guard name == other.name else {
       throw MergeError.invalidNames
-      return self
     }
-    return TypeWithPropInfo(
+    return TypeProperties(
       name: name,
       properties: Array(Set(properties).union(Set(other.properties))))
   }
+}
+
+extension TypeProperties.Modifier: CustomStringConvertible, CustomDebugStringConvertible {
+  public var description: String {
+    var outputValues: [String] = []
+    // Order is important here! Access control modifiers should always go before scope modifiers
+    // Access control modifiers
+    if contains(.public) { outputValues.append("public") }
+    if contains(.private) { outputValues.append("private") }
+    if contains(.privateSet) { outputValues.append("private(set)") }
+    if contains(.fileprivate) { outputValues.append("fileprivate") }
+    if contains(.internal) { outputValues.append("internal") }
+    // Scope modifiers
+    if contains(.static) { outputValues.append("static") }
+    if contains(.instance) { outputValues.append("instance") }
+    return outputValues.joined(separator: ",")
+  }
+
+  public var debugDescription: String { description }
 }

--- a/Sources/SwiftInspectorCore/PropertyAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/PropertyAnalyzer.swift
@@ -1,0 +1,248 @@
+// Created by Tyler Hedrick on 8/14/20.
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import SwiftSyntax
+
+// MARK: - TypeLocationAnalyzer
+
+public final class PropertyAnalyzer: Analyzer {
+
+  /// - Parameter typeName: The name of the type to get property information for
+  /// - Parameter cachedSyntaxTree: The cached syntax tree to return the AST tree from
+  public init(typeName: String, cachedSyntaxTree: CachedSyntaxTree = .init()) {
+    self.typeName = typeName
+    self.cachedSyntaxTree = cachedSyntaxTree
+  }
+
+  /// Finds the location(s) of the specified type name in the Swift file
+  /// - Parameter fileURL: The fileURL where the Swift file is located
+  public func analyze(fileURL: URL) throws -> TypeWithPropInfo? {
+    let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
+    var result: TypeWithPropInfo?
+    let visitor = TypeSyntaxVisitor() { [unowned self] typeWithPropInfo in
+      guard self.typeName == typeWithPropInfo.name else { return }
+      result = try? typeWithPropInfo.merge(with: result)
+    }
+    visitor.walk(syntax)
+    return result
+  }
+
+  // MARK: Private
+
+  private let cachedSyntaxTree: CachedSyntaxTree
+  private let typeName: String
+}
+
+// MARK: - TypeLocationSyntaxVisitor
+
+private final class TypeSyntaxVisitor: SyntaxVisitor {
+
+  init(onNodeVisit: @escaping (_ info: TypeWithPropInfo) -> Void) {
+    self.onNodeVisit = onNodeVisit
+  }
+
+  override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    processNode(node, withName: node.identifier.text, members: node.members.members)
+    return .visitChildren
+  }
+
+  override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    processNode(node, withName: node.identifier.text, members: node.members.members)
+    return .visitChildren
+  }
+
+  override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    processNode(node, withName: node.identifier.text, members: node.members.members)
+    return .visitChildren
+  }
+
+  override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    processNode(node, withName: node.identifier.text, members: node.members.members)
+    return .visitChildren
+  }
+
+  override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+    if let typeIdentifier = node.extendedType.as(SimpleTypeIdentifierSyntax.self) {
+      processNode(node, withName: typeIdentifier.name.text, members: node.members.members)
+    }
+    return .visitChildren
+  }
+
+  // MARK: Private
+
+  private let onNodeVisit: (_ info: TypeWithPropInfo) -> Void
+
+  private func processNode<Node>(_ node: Node, withName name: String, members: MemberDeclListSyntax) where Node: SyntaxProtocol {
+    var result = [TypeWithPropInfo.PropInfo]()
+    let propertyVisitor = PropertySyntaxVisitor(parentName: name) { info in
+      result.append(info)
+    }
+    propertyVisitor.walk(node)
+    onNodeVisit(.init(name: name, properties: result))
+  }
+}
+
+// MARK: - PropertySyntaxVisitor
+
+private final class PropertySyntaxVisitor: SyntaxVisitor {
+
+  init(parentName: String, onNodeVisit: @escaping (_ info: TypeWithPropInfo.PropInfo) -> Void) {
+    self.parentName = parentName
+    self.onNodeVisit = onNodeVisit
+  }
+
+  override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+    var leadingTrivia: Trivia? = node.leadingTrivia
+    var access: TypeWithPropInfo.Access = .internal
+    var scope: TypeWithPropInfo.Scope = .instance
+
+    node.modifiers?.forEach { modifier in
+      // leading trivia is on the first modifier, or the node itself if no modifiers are present
+      leadingTrivia = leadingTrivia ?? modifier.leadingTrivia
+      // This attempts to get any access information from the node's modifiers
+      if let modifierAccess = TypeWithPropInfo.Access(rawValue: modifier.name.text) {
+        access = modifierAccess
+      }
+      // this attempts to get any scope information from the node's modifiers
+      if let modifierScope = TypeWithPropInfo.Scope(rawValue: modifier.name.text) {
+        scope = modifierScope
+      }
+    }
+
+    // in practice this `bindings` array only has 1 element
+    node.bindings.forEach { binding in
+      if let identifier = binding.pattern.as(IdentifierPatternSyntax.self) {
+        if
+          let typeAnnotation = binding.typeAnnotation,
+          let simpleTypeIdentifier = typeAnnotation.type.as(SimpleTypeIdentifierSyntax.self)
+        {
+          onNodeVisit(.init(
+            name: identifier.identifier.text,
+            typeAnnotation: simpleTypeIdentifier.name.text,
+            comment: comment(from: leadingTrivia),
+            access: access,
+            scope: scope))
+          return
+        }
+        // no type annotation was found. In this case it's much more complicated to get
+        // the type information for a variable.
+        // TODO: Include logic to get types of any variable declaration
+        onNodeVisit(.init(
+          name: identifier.identifier.text,
+          typeAnnotation: nil,
+          comment: comment(from: leadingTrivia),
+          access: access,
+          scope: scope))
+      }
+    }
+
+    return .skipChildren
+  }
+
+  // MARK: Private
+
+  private let parentName: String
+  private let onNodeVisit: (_ info: TypeWithPropInfo.PropInfo) -> Void
+
+  private func comment(from trivia: Trivia?) -> String {
+    guard let trivia = trivia else { return "" }
+    return trivia.compactMap { piece -> String? in
+      switch piece {
+      case .lineComment(let str): return str
+      case .blockComment(let str): return str
+      case .docLineComment(let str): return str
+      case .docBlockComment(let str): return str
+      default: return nil
+      }
+    }.joined(separator: "\n")
+  }
+}
+
+// MARK: - TypeWithPropInfo
+
+/// Information about a located type. Indices start with 0.
+public struct TypeWithPropInfo: Hashable {
+
+  public enum Access: String {
+    case `public`
+    case `internal`
+    case `private`
+    case `fileprivate`
+  }
+
+  public enum Scope: String {
+    case instance
+    case `static`
+  }
+
+  public struct PropInfo: Hashable {
+    /// The name of the property
+    public let name: String
+    /// The Type annotation of the property if it's present
+    public let typeAnnotation: String?
+    /// Any comments associated with the property
+    public let comment: String
+    /// Access control of this property
+    public let access: Access
+    /// Scope of this property
+    public let scope: Scope
+  }
+
+  /// The name of the type.
+  public let name: String
+  /// The properites on this type
+  public let properties: [PropInfo]
+}
+
+extension TypeWithPropInfo {
+  struct MergeError: Error, CustomStringConvertible {
+
+    init(errorMessage: String) {
+      self.errorMessage = errorMessage
+    }
+
+    var description: String { errorMessage }
+
+    private let errorMessage: String
+  }
+}
+
+extension TypeWithPropInfo.MergeError {
+  static var invalidNames = TypeWithPropInfo.MergeError(
+    errorMessage: "Invalid types - the type names must match to be merged.")
+}
+
+extension TypeWithPropInfo {
+  func merge(with other: TypeWithPropInfo?) throws -> TypeWithPropInfo {
+    guard let other = other else {
+      return self
+    }
+    guard name == other.name else {
+      throw MergeError.invalidNames
+      return self
+    }
+    return TypeWithPropInfo(
+      name: name,
+      properties: Array(Set(properties).union(Set(other.properties))))
+  }
+}

--- a/Sources/SwiftInspectorCore/PropertyAnalyzer.swift
+++ b/Sources/SwiftInspectorCore/PropertyAnalyzer.swift
@@ -230,13 +230,18 @@ public struct TypeProperties: Hashable {
   public struct Modifier: Hashable, OptionSet {
     public let rawValue: Int
 
+    // general accessors
     public static let `internal` = Modifier(rawValue: 1 << 0)
     public static let `public` = Modifier(rawValue: 1 << 1)
     public static let `private` = Modifier(rawValue: 1 << 2)
-    public static let privateSet = Modifier(rawValue: 1 << 3)
-    public static let `fileprivate` = Modifier(rawValue: 1 << 4)
-    public static let `instance` = Modifier(rawValue: 1 << 5)
-    public static let `static` = Modifier(rawValue: 1 << 6)
+    public static let `fileprivate` = Modifier(rawValue: 1 << 3)
+    // set accessors
+    public static let privateSet = Modifier(rawValue: 1 << 4)
+    public static let internalSet = Modifier(rawValue: 1 << 5)
+    public static let publicSet = Modifier(rawValue: 1 << 6)
+    // access control
+    public static let `instance` = Modifier(rawValue: 1 << 7)
+    public static let `static` = Modifier(rawValue: 1 << 8)
 
     public init(rawValue: Int)  {
       self.rawValue = rawValue
@@ -246,8 +251,10 @@ public struct TypeProperties: Hashable {
       switch stringValue {
       case "public": self = .public
       case "private": self = .private
-      case "private(set)": self = .privateSet
       case "fileprivate": self = .fileprivate
+      case "private(set)": self = .privateSet
+      case "internal(set)": self = .internalSet
+      case "public(set)": self = .publicSet
       case "internal": self = .internal
       case "static": self = .static
       default: self = []
@@ -302,23 +309,4 @@ extension TypeProperties {
       name: name,
       properties: Array(Set(properties).union(Set(other.properties))))
   }
-}
-
-extension TypeProperties.Modifier: CustomStringConvertible, CustomDebugStringConvertible {
-  public var description: String {
-    var outputValues: [String] = []
-    // Order is important here! Access control modifiers should always go before scope modifiers
-    // Access control modifiers
-    if contains(.public) { outputValues.append("public") }
-    if contains(.private) { outputValues.append("private") }
-    if contains(.privateSet) { outputValues.append("private(set)") }
-    if contains(.fileprivate) { outputValues.append("fileprivate") }
-    if contains(.internal) { outputValues.append("internal") }
-    // Scope modifiers
-    if contains(.static) { outputValues.append("static") }
-    if contains(.instance) { outputValues.append("instance") }
-    return outputValues.joined(separator: ",")
-  }
-
-  public var debugDescription: String { description }
 }

--- a/Sources/SwiftInspectorCore/Tests/PropertyAnalzyerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/PropertyAnalzyerSpec.swift
@@ -393,6 +393,50 @@ final class PropertyAnalyzerSpec: QuickSpec {
         }
       }
 
+      context("when there is a public internal(set) property") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            public internal(set) var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeProperties.PropertyData(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              modifiers: [.public, .internalSet, .instance])
+          ]
+        }
+      }
+
+      context("when there is a internal public(set) property") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            internal public(set) var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeProperties.PropertyData(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              modifiers: [.publicSet, .internal, .instance])
+          ]
+        }
+      }
+
       context("when there is a fileprivate property") {
         beforeEach {
           let content = """

--- a/Sources/SwiftInspectorCore/Tests/PropertyAnalzyerSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/PropertyAnalzyerSpec.swift
@@ -1,0 +1,468 @@
+// Created by Tyler Hedrick on 3/27/20.
+//
+// Copyright (c) 2020 Tyler Hedrick
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Nimble
+import Quick
+import Foundation
+
+@testable import SwiftInspectorCore
+
+final class PropertyAnalyzerSpec: QuickSpec {
+  override func spec() {
+    var fileURL: URL!
+    var sut = PropertyAnalyzer(typeName: "FakeType")
+
+    beforeEach {
+      sut = PropertyAnalyzer(typeName: "FakeType")
+    }
+
+    afterEach {
+      guard let fileURL = fileURL else {
+        return
+      }
+      try? Temporary.removeItem(at: fileURL)
+    }
+
+    describe("TypeWithPropInfo.merge(other:)") {
+      let type1 = TypeWithPropInfo(
+        name: "MyType",
+        properties: [
+          TypeWithPropInfo.PropInfo(name: "thing", typeAnnotation: "String", comment: "", access: .public, scope: .instance)
+      ])
+      let type2 = TypeWithPropInfo(
+        name: "MyType",
+        properties: [
+          TypeWithPropInfo.PropInfo(name: "foo", typeAnnotation: "Int", comment: "", access: .public, scope: .instance)
+      ])
+      let type3 = TypeWithPropInfo(
+        name: "AnotherType",
+        properties: [
+          TypeWithPropInfo.PropInfo(name: "foo", typeAnnotation: "Int", comment: "", access: .public, scope: .instance)
+      ])
+
+      context("when both types have the same name") {
+        let result = try? type1.merge(with: type2)
+        it("succeeds") {
+          expect(result?.name) == "MyType"
+        }
+
+        it("has merged props") {
+          let set = Set(result?.properties ?? [])
+          let expectedSet: Set<TypeWithPropInfo.PropInfo> = [
+            TypeWithPropInfo.PropInfo(name: "thing", typeAnnotation: "String", comment: "", access: .public, scope: .instance),
+            TypeWithPropInfo.PropInfo(name: "foo", typeAnnotation: "Int", comment: "", access: .public, scope: .instance)
+          ]
+          expect(set) == expectedSet
+        }
+      }
+
+      context("when the types don't match") {
+        it("fails to merge and asserts") {
+          expect { try type1.merge(with: type3) }.to(throwError())
+        }
+      }
+
+      context("when the other type is nil") {
+        it("returns the original") {
+          expect(try? type1.merge(with: nil)) == type1
+        }
+      }
+    }
+
+    describe("analyze(fileURL:)") {
+      context("when there are no properties") {
+        beforeEach {
+          let content = """
+                        public final class FakeType {}
+                        """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("returns type info with empty property list") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties).to(beEmpty())
+        }
+      }
+
+      context("when there is a property") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            public var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the type name") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.name) == "FakeType"
+        }
+
+        it("returns nil if the type name is not present") {
+          let sut = PropertyAnalyzer(typeName: "AnotherType")
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result).to(beNil())
+        }
+
+        it("detects the properties") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              access: .public,
+              scope: .instance)
+          ]
+        }
+      }
+
+      context("when there is a property (struct)") {
+        beforeEach {
+          let content = """
+          public struct FakeType {
+            public var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the type name") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.name) == "FakeType"
+        }
+
+        it("detects the properties") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              access: .public,
+              scope: .instance)
+          ]
+        }
+      }
+
+      context("when there is a property (enum)") {
+        beforeEach {
+          let content = """
+          public enum FakeType {
+            public var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the type name") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.name) == "FakeType"
+        }
+
+        it("detects the properties") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              access: .public,
+              scope: .instance)
+          ]
+        }
+      }
+
+      context("when there is a property (protocol)") {
+        beforeEach {
+          let content = """
+          public protocol FakeType {
+            var thing: String { get }
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the type name") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.name) == "FakeType"
+        }
+
+        it("detects the properties") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              access: .internal,
+              scope: .instance)
+          ]
+        }
+      }
+
+      context("when there is a property extension") {
+        beforeEach {
+          let content = """
+          public class FakeType { }
+
+          extension FakeType {
+            var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the type name") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.name) == "FakeType"
+        }
+
+        it("detects the properties") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              access: .internal,
+              scope: .instance)
+          ]
+        }
+      }
+
+      context("when there are multiple properites") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            public var thing: String = "Hello, World"
+            var foo: Int = 4
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the properties") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          let propSet = Set(result?.properties ?? [])
+          let expectedPropSet: Set<TypeWithPropInfo.PropInfo> = [
+            .init(name: "thing", typeAnnotation: "String", comment: "", access: .public, scope: .instance),
+            .init(name: "foo", typeAnnotation: "Int", comment: "", access: .internal, scope: .instance)
+          ]
+          expect(propSet) == expectedPropSet
+        }
+      }
+
+      context("when there is a static property") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            public static var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              access: .public,
+              scope: .static)
+          ]
+        }
+      }
+
+      context("when there is a private property") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            private static var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              access: .private,
+              scope: .static)
+          ]
+        }
+      }
+
+      context("when there is a fileprivate property") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            fileprivate static var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              access: .fileprivate,
+              scope: .static)
+          ]
+        }
+      }
+
+      context("when there is no type annotation") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            private static var thing = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property with no type information") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: nil,
+              comment: "",
+              access: .private,
+              scope: .static)
+          ]
+        }
+      }
+
+      context("when there is a line comment") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            // The thing
+            public var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property with the comment") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "// The thing",
+              access: .public,
+              scope: .instance)
+          ]
+        }
+      }
+
+      context("when there is a doc line comment") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            /// The thing
+            public var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property with the comment") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "/// The thing",
+              access: .public,
+              scope: .instance)
+          ]
+        }
+      }
+
+      context("when there is a block comment") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            /* The thing */
+            public var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property with the comment") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "/* The thing */",
+              access: .public,
+              scope: .instance)
+          ]
+        }
+      }
+
+      context("when there is a doc block comment") {
+        beforeEach {
+          let content = """
+          public final class FakeType {
+            /** The thing */
+            public var thing: String = "Hello, World"
+          }
+          """
+          fileURL = try? Temporary.makeFile(content: content)
+        }
+
+        it("detects the property with the comment") {
+          let result = try? sut.analyze(fileURL: fileURL)
+          expect(result?.properties) == [
+            TypeWithPropInfo.PropInfo(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "/** The thing */",
+              access: .public,
+              scope: .instance)
+          ]
+        }
+      }
+
+    }
+  }
+}

--- a/Sources/SwiftInspectorCore/Tests/TypePropertiesSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypePropertiesSpec.swift
@@ -38,7 +38,7 @@ final class TypePropertiesSpec: QuickSpec {
             name: "thing",
             typeAnnotation: "String",
             comment: "",
-            modifier: [.public, .instance])
+            modifiers: [.public, .instance])
       ])
       let type2 = TypeProperties(
         name: "MyType",
@@ -47,7 +47,7 @@ final class TypePropertiesSpec: QuickSpec {
             name: "foo",
             typeAnnotation: "Int",
             comment: "",
-            modifier: [.public, .instance])
+            modifiers: [.public, .instance])
       ])
       let type3 = TypeProperties(
         name: "AnotherType",
@@ -56,7 +56,7 @@ final class TypePropertiesSpec: QuickSpec {
             name: "foo",
             typeAnnotation: "Int",
             comment: "",
-            modifier: [.public, .instance])
+            modifiers: [.public, .instance])
       ])
 
       context("when both types have the same name") {
@@ -72,12 +72,12 @@ final class TypePropertiesSpec: QuickSpec {
               name: "thing",
               typeAnnotation: "String",
               comment: "",
-              modifier: [.public, .instance]),
+              modifiers: [.public, .instance]),
             TypeProperties.PropertyData(
               name: "foo",
               typeAnnotation: "Int",
               comment: "",
-              modifier: [.public, .instance])
+              modifiers: [.public, .instance])
           ]
           expect(set) == expectedSet
         }

--- a/Sources/SwiftInspectorCore/Tests/TypePropertiesSpec.swift
+++ b/Sources/SwiftInspectorCore/Tests/TypePropertiesSpec.swift
@@ -1,0 +1,99 @@
+// Created by Tyler Hedrick on 8/18/20.
+//
+// Copyright (c) 2020 Tyler Hedrick
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Nimble
+import Quick
+import Foundation
+
+@testable import SwiftInspectorCore
+
+final class TypePropertiesSpec: QuickSpec {
+  override func spec() {
+    describe("TypeProperties.merge(other:)") {
+      let type1 = TypeProperties(
+        name: "MyType",
+        properties: [
+          TypeProperties.PropertyData(
+            name: "thing",
+            typeAnnotation: "String",
+            comment: "",
+            modifier: [.public, .instance])
+      ])
+      let type2 = TypeProperties(
+        name: "MyType",
+        properties: [
+          TypeProperties.PropertyData(
+            name: "foo",
+            typeAnnotation: "Int",
+            comment: "",
+            modifier: [.public, .instance])
+      ])
+      let type3 = TypeProperties(
+        name: "AnotherType",
+        properties: [
+          TypeProperties.PropertyData(
+            name: "foo",
+            typeAnnotation: "Int",
+            comment: "",
+            modifier: [.public, .instance])
+      ])
+
+      context("when both types have the same name") {
+        let result = try? type1.merge(with: type2)
+        it("succeeds") {
+          expect(result?.name) == "MyType"
+        }
+
+        it("has merged props") {
+          let set = Set(result?.properties ?? [])
+          let expectedSet: Set<TypeProperties.PropertyData> = [
+            TypeProperties.PropertyData(
+              name: "thing",
+              typeAnnotation: "String",
+              comment: "",
+              modifier: [.public, .instance]),
+            TypeProperties.PropertyData(
+              name: "foo",
+              typeAnnotation: "Int",
+              comment: "",
+              modifier: [.public, .instance])
+          ]
+          expect(set) == expectedSet
+        }
+      }
+
+      context("when the types don't match") {
+        it("fails to merge and asserts") {
+          expect { try type1.merge(with: type3) }.to(throwError())
+        }
+      }
+
+      context("when the other type is nil") {
+        it("returns the original") {
+          expect(try? type1.merge(with: nil)) == type1
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Changes

This adds a new property analyzer and command. As with the `TypeCommand` / `TypeAnalyzer` this has more information in the analyzer than it does in the command.

Here's the command
```
swift-inspector properties --help
OVERVIEW: Finds property information for the provided type

USAGE: SwiftInspector properties --name <name> --path <path>

OPTIONS:
  --name <name>           The name of the type to find property information on 
        This may be a enum, class, struct, or protocol.
  --path <path>           The absolute path of the file to inspect 
  -h, --help              Show help information.
```

This command will find property information for a provided type including:
- Type name
- Each property includes:
  - Property name
  - Access (public, private, internal, fileprivate)
  - Scope (instance, scope)
  - Comment (Analyzer only)
  - Property type (Analyzer only)

## Please review
@fdiaz 