### PR TITLE
[iOS] Rename executable from SwiftInspector to swiftinspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ build:
 
 .PHONY: install
 install: build 
-	install ".build/release/swift-inspector" "$(bindir)"
+	install ".build/release/swiftinspector" "$(bindir)"
 
 .PHONY: uninstall
 uninstall:
-	rm -rf "$(bindir)/swift-inspector"
+	rm -rf "$(bindir)/swiftinspector"
 
 .PHONY: clean
 clean:

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
     .macOS(.v10_13)
   ],
   products: [
-    .executable(name: "swift-inspector", targets: ["SwiftInspector"]),
+    .executable(name: "swiftinspector", targets: ["SwiftInspector"]),
     .library(name: "SwiftInspectorCommands", targets: ["SwiftInspectorCommands"]),
     .library(name: "SwiftInspectorCore", targets: ["SwiftInspectorCore"])
   ],

--- a/Sources/SwiftInspectorCommands/InspectorCommand.swift
+++ b/Sources/SwiftInspectorCommands/InspectorCommand.swift
@@ -28,7 +28,7 @@ public struct InspectorCommand: ParsableCommand {
   public init() {}
 
   public static var configuration = CommandConfiguration(
-    commandName: "swift-inspector",
+    commandName: "swiftinspector",
     abstract: "A command line tool to help inspect usage of classes, protocols, properties, etc in a Swift codebase.",
     subcommands: [
       ImportsCommand.self,

--- a/Sources/SwiftInspectorCommands/Tests/TestTask.swift
+++ b/Sources/SwiftInspectorCommands/Tests/TestTask.swift
@@ -31,7 +31,7 @@ struct TestTask {
   /// - Parameter arguments: A set of arguments to pass to the Swift Inspector executable
   static func run(withArguments arguments: [String]) throws -> TaskStatus {
     let process = Process()
-    process.executableURL = productsDirectory.appendingPathComponent("swift-inspector")
+    process.executableURL = productsDirectory.appendingPathComponent("swiftinspector")
     process.arguments = arguments
 
     let standardOutputPipe = Pipe()


### PR DESCRIPTION
I started this project intending to call the executable `SwiftInspector` but pretty quickly it became clear that we should use `swift-inspector` for the binary name.

This PR accomplishes that by no longer renaming the binary after building for release.