### PR TITLE
Allow small code coverage drops

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
+coverage:
+  status:
+    # PRs only
+    patch:
+      default:
+        threshold: 0.1%
 ignore:
   - "Sources/SwiftInspectorCommands/Tests"
   - "Sources/SwiftInspectorCore/Tests"


### PR DESCRIPTION
I noticed that [in this PR](https://github.com/fdiaz/SwiftInspector/pull/47) that we had some failures with code coverage dropping a tiny percentage after we migrated SwiftArgumentParser to its latest version. I think it should be possible to drop code coverage on a PR by a small amount for these types of changes in the future.

Docs: https://docs.codecov.io/docs/commit-status#threshold