### PR TITLE
ImportsAnalyzer -> ImportSyntaxReader. Also create StandardAnalyzer

### DIFF
--- a/Sources/SwiftInspectorAnalyzers/ImportsAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/ImportsAnalyzer.swift
@@ -1,0 +1,35 @@
+// Created by Dan Federman on 1/28/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import SwiftInspectorVisitors
+
+extension StandardAnalyzer {
+
+  public func analyzeImports(fileURL: URL) throws -> [ImportStatement] {
+    let visitor = ImportSyntaxReader()
+    try analyze(fileURL: fileURL, withVisitor: visitor)
+    return visitor.imports
+  }
+}

--- a/Sources/SwiftInspectorAnalyzers/StandardAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/StandardAnalyzer.swift
@@ -37,7 +37,7 @@ public struct StandardAnalyzer {
   /// - Parameters:
   ///   - fileURL: The fileURL where the Swift file is located
   ///   - visitor: A Swift syntax visitor to use to analyze the provided file
-  public func analyze<Visitor: SyntaxVisitor>(fileURL: URL, withVisitor visitor: Visitor) throws
+  func analyze(fileURL: URL, withVisitor visitor: SyntaxVisitor) throws
   {
     let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
     visitor.walk(syntax)
@@ -48,7 +48,7 @@ public struct StandardAnalyzer {
   ///   - fileURL: The fileURL where the Swift file is located
   ///   - visitor: A Swift syntax rewriter to use to analyze the provided file
   /// - Note: Use a visitor when possible. Rewriters should be used to work around this bug: https://bugs.swift.org/browse/SR-11591
-  public func analyze<Visitor: SyntaxRewriter>(fileURL: URL, withVisitor visitor: Visitor) throws
+  func analyze(fileURL: URL, withVisitor visitor: SyntaxRewriter) throws
   {
     let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
     _ = visitor.visit(syntax)

--- a/Sources/SwiftInspectorAnalyzers/StandardAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/StandardAnalyzer.swift
@@ -1,0 +1,61 @@
+// Created by Dan Federman on 1/27/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import SwiftSyntax
+
+/// A struct that enables analyzing a Swift file at a URL with a Swift syntax visitor.
+public struct StandardAnalyzer {
+
+  /// - Parameter cachedSyntaxTree: The cached syntax tree to return the AST tree from
+  public init(cachedSyntaxTree: CachedSyntaxTree = .init()) {
+    self.cachedSyntaxTree = cachedSyntaxTree
+  }
+
+  /// Analyzes a Swift file with the provided visitor
+  /// - Parameters:
+  ///   - fileURL: The fileURL where the Swift file is located
+  ///   - visitor: A Swift syntax visitor to use to analyze the provided file
+  public func analyze<Visitor: SyntaxVisitor>(fileURL: URL, withVisitor visitor: Visitor) throws
+  {
+    let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
+    visitor.walk(syntax)
+  }
+
+  /// Analyzes a Swift file with the provide visitor
+  /// - Parameters:
+  ///   - fileURL: The fileURL where the Swift file is located
+  ///   - visitor: A Swift syntax rewriter to use to analyze the provided file
+  /// - Note: Use a visitor when possible. Rewriters should be used to work around this bug: https://bugs.swift.org/browse/SR-11591
+  public func analyze<Visitor: SyntaxRewriter>(fileURL: URL, withVisitor visitor: Visitor) throws
+  {
+    let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
+    _ = visitor.visit(syntax)
+  }
+
+  // MARK: Private
+
+  private let cachedSyntaxTree: CachedSyntaxTree
+
+}

--- a/Sources/SwiftInspectorAnalyzers/Tests/StandardAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorAnalyzers/Tests/StandardAnalyzerSpec.swift
@@ -26,8 +26,9 @@ import Foundation
 import Nimble
 import Quick
 import SwiftSyntax
+import SwiftInspectorTestHelpers
 
-@testable import SwiftInspectorTestHelpers
+@testable import SwiftInspectorAnalyzers
 
 final class StandardAnalyzerSpec: QuickSpec {
 
@@ -47,11 +48,21 @@ final class StandardAnalyzerSpec: QuickSpec {
   }
 
   override func spec() {
+    var fileURL: URL!
     describe("analyze(fileURL:withVisitor:)") {
+      beforeEach {
+        fileURL = try? Temporary.makeFile(content: "if true {}")
+      }
+      afterEach {
+        guard let fileURL = fileURL else {
+          return
+        }
+        try? Temporary.removeItem(at: fileURL)
+      }
       context("with a visitor") {
         it("walks the visitor over the content") {
           let visitor = MockVisitor()
-          try VisitorExecutor.walkVisitor(visitor, overContent: "if true {}")
+          try StandardAnalyzer().analyze(fileURL: fileURL, withVisitor: visitor)
 
           expect(visitor.ifStatementSyntaxVisitCount) == 1
         }
@@ -60,7 +71,7 @@ final class StandardAnalyzerSpec: QuickSpec {
       context("with a rewriter") {
         it("walks the rewriter over the content") {
           let visitor = MockRewriter()
-          try VisitorExecutor.walkVisitor(visitor, overContent: "if true {}")
+          try StandardAnalyzer().analyze(fileURL: fileURL, withVisitor: visitor)
 
           expect(visitor.ifStatementSyntaxVisitCount) == 1
         }

--- a/Sources/SwiftInspectorAnalyzers/Tests/StandardAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorAnalyzers/Tests/StandardAnalyzerSpec.swift
@@ -1,0 +1,70 @@
+// Created by Dan Federman on 1/27/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Nimble
+import Quick
+import SwiftSyntax
+
+@testable import SwiftInspectorTestHelpers
+
+final class StandardAnalyzerSpec: QuickSpec {
+
+  private final class MockVisitor: SyntaxVisitor {
+    var ifStatementSyntaxVisitCount = 0
+    override func visitPost(_ node: IfStmtSyntax) {
+      ifStatementSyntaxVisitCount += 1
+    }
+  }
+
+  private final class MockRewriter: SyntaxRewriter {
+    var ifStatementSyntaxVisitCount = 0
+    override func visit(_ node: IfStmtSyntax) -> StmtSyntax {
+      ifStatementSyntaxVisitCount += 1
+      return super.visit(node)
+    }
+  }
+
+  override func spec() {
+    describe("analyze(fileURL:withVisitor:)") {
+      context("with a visitor") {
+        it("walks the visitor over the content") {
+          let visitor = MockVisitor()
+          try VisitorExecutor.walkVisitor(visitor, overContent: "if true {}")
+
+          expect(visitor.ifStatementSyntaxVisitCount) == 1
+        }
+      }
+
+      context("with a rewriter") {
+        it("walks the rewriter over the content") {
+          let visitor = MockRewriter()
+          try VisitorExecutor.walkVisitor(visitor, overContent: "if true {}")
+
+          expect(visitor.ifStatementSyntaxVisitCount) == 1
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwiftInspectorCommands/ImportsCommand.swift
+++ b/Sources/SwiftInspectorCommands/ImportsCommand.swift
@@ -25,6 +25,7 @@
 import ArgumentParser
 import Foundation
 import SwiftInspectorAnalyzers
+import SwiftInspectorVisitors
 
 final class ImportsCommand: ParsableCommand {
   static var configuration = CommandConfiguration(
@@ -41,13 +42,14 @@ final class ImportsCommand: ParsableCommand {
   /// Runs the command
   func run() throws {
     let cachedSyntaxTree = CachedSyntaxTree()
-    let analyzer = ImportsAnalyzer(cachedSyntaxTree: cachedSyntaxTree)
+    let analyzer = StandardAnalyzer(cachedSyntaxTree: cachedSyntaxTree)
     let fileURL = URL(fileURLWithPath: path)
 
     let outputArray = try FileManager.default.swiftFiles(at: fileURL)
       .reduce(Set<String>()) { result, url in
-        let importStatements = try analyzer.analyze(fileURL: url)
-        let output = importStatements.map { outputString(from: $0) }
+        let reader = ImportSyntaxReader()
+        try analyzer.analyze(fileURL: url, withVisitor: reader)
+        let output = reader.imports.map { outputString(from: $0) }
         return result.union(output)
     }
 

--- a/Sources/SwiftInspectorCommands/ImportsCommand.swift
+++ b/Sources/SwiftInspectorCommands/ImportsCommand.swift
@@ -47,9 +47,8 @@ final class ImportsCommand: ParsableCommand {
 
     let outputArray = try FileManager.default.swiftFiles(at: fileURL)
       .reduce(Set<String>()) { result, url in
-        let reader = ImportSyntaxReader()
-        try analyzer.analyze(fileURL: url, withVisitor: reader)
-        let output = reader.imports.map { outputString(from: $0) }
+        let output = try analyzer.analyzeImports(fileURL: url)
+          .map { outputString(from: $0) }
         return result.union(output)
     }
 

--- a/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
@@ -27,7 +27,7 @@ import SwiftSyntax
 
 public final class GenericRequirementVisitor: SyntaxVisitor {
 
-  public var genericRequirements = [GenericRequirement]()
+  public private(set) var genericRequirements = [GenericRequirement]()
 
   public override func visit(_ node: SameTypeRequirementSyntax) -> SyntaxVisitorContinueKind {
     genericRequirements.append(GenericRequirement(node: node))

--- a/Sources/SwiftInspectorVisitors/ImportSyntaxReader.swift
+++ b/Sources/SwiftInspectorVisitors/ImportSyntaxReader.swift
@@ -27,7 +27,7 @@ import SwiftSyntax
 
 // TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
 public final class ImportSyntaxReader: SyntaxRewriter {
-  public var imports: [ImportStatement] = []
+  public private(set) var imports: [ImportStatement] = []
 
   public override func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
     let statement = importStatement(from: node)

--- a/Sources/SwiftInspectorVisitors/ImportSyntaxReader.swift
+++ b/Sources/SwiftInspectorVisitors/ImportSyntaxReader.swift
@@ -25,30 +25,15 @@
 import Foundation
 import SwiftSyntax
 
-public final class ImportsAnalyzer: Analyzer {
+// TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
+public final class ImportSyntaxReader: SyntaxRewriter {
+  public var imports: [ImportStatement] = []
 
-  /// - Parameter cachedSyntaxTree: The cached syntax tree to return the AST tree from
-  public init(cachedSyntaxTree: CachedSyntaxTree = .init()) {
-    self.cachedSyntaxTree = cachedSyntaxTree
+  public override func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
+    let statement = importStatement(from: node)
+    imports.append(statement)
+    return super.visit(node)
   }
-
-  /// Analyzes the imports of the Swift file
-  /// - Parameter fileURL: The fileURL where the Swift file is located
-  public func analyze(fileURL: URL) throws -> [ImportStatement] {
-    let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
-    var statements: [ImportStatement] = []
-    let reader = ImportSyntaxReader() { [unowned self] node in
-      let statement = self.importStatement(from: node)
-      statements.append(statement)
-    }
-    _ = reader.visit(syntax)
-
-    return statements
-  }
-
-  // MARK: Private
-
-  private let cachedSyntaxTree: CachedSyntaxTree
 
   private func importStatement(from syntaxNode: ImportDeclSyntax) -> ImportStatement {
     let attribute = findAttribute(from: syntaxNode)
@@ -130,21 +115,7 @@ public final class ImportsAnalyzer: Analyzer {
   }
 }
 
-// TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
-private final class ImportSyntaxReader: SyntaxRewriter {
-  init(onNodeVisit: @escaping (ImportDeclSyntax) -> Void) {
-    self.onNodeVisit = onNodeVisit
-  }
-
-  override func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
-    onNodeVisit(node)
-    return super.visit(node)
-  }
-
-  let onNodeVisit: (ImportDeclSyntax) -> Void
-}
-
-public struct ImportStatement: Hashable {
+public struct ImportStatement: Codable, Hashable {
   public var attribute: String = ""
   public var kind: String = ""
   public let mainModule: String

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,9 @@ coverage:
     patch:
       default:
         threshold: 0.1%
+    project:
+      default:
+        threshold: 0.1%
 ignore:
   - "Sources/SwiftInspectorAnalyzers/Tests"
   - "Sources/SwiftInspectorCommands/Tests"


### PR DESCRIPTION
Migrates the import analyzer underlying tooling down into the Visitor module. Deletes the remainder of `ImportAnalyzer` in favor of a new `StandardAnalyzer`