### PR TITLE
Create StructVisitor

### DIFF
--- a/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
@@ -31,14 +31,20 @@ public final class GenericRequirementVisitor: SyntaxVisitor {
 
   public override func visit(_ node: SameTypeRequirementSyntax) -> SyntaxVisitorContinueKind {
     genericRequirements.append(GenericRequirement(node: node))
-    return .visitChildren
+    // We only care about siblings, not children.
+    return .skipChildren
   }
 
   public override func visit(_ node: ConformanceRequirementSyntax) -> SyntaxVisitorContinueKind {
     genericRequirements.append(GenericRequirement(node: node))
-    return .visitChildren
+    // We only care about siblings, not children.
+    return .skipChildren
   }
 
+  public override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
+    // We don't care about the internals of a type with generic requirements.
+    .skipChildren
+  }
 }
 
 public struct GenericRequirement: Codable, Equatable {

--- a/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
@@ -31,18 +31,19 @@ public final class GenericRequirementVisitor: SyntaxVisitor {
 
   public override func visit(_ node: SameTypeRequirementSyntax) -> SyntaxVisitorContinueKind {
     genericRequirements.append(GenericRequirement(node: node))
-    // We only care about siblings, not children.
+    // Children don't have any more information about generic requirements, so don't visit them.
     return .skipChildren
   }
 
   public override func visit(_ node: ConformanceRequirementSyntax) -> SyntaxVisitorContinueKind {
     genericRequirements.append(GenericRequirement(node: node))
-    // We only care about siblings, not children.
+    // Children don't have any more information about generic requirements, so don't visit them.
     return .skipChildren
   }
 
   public override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
-    // We don't care about the internals of a type with generic requirements.
+    // A member declaration block means we've found the body of the type.
+    // There's nothing in this body that would help us determine generic requirements.
     .skipChildren
   }
 }

--- a/Sources/SwiftInspectorVisitors/StructVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/StructVisitor.swift
@@ -31,6 +31,7 @@ public final class StructVisitor: SyntaxVisitor {
     self.parentTypeName = parentTypeName
   }
 
+  /// All of the structs found by this visitor.
   public var structs: [StructInfo] {
     [structInfo].compactMap { $0 } + innerStructs
   }

--- a/Sources/SwiftInspectorVisitors/StructVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/StructVisitor.swift
@@ -1,0 +1,121 @@
+// Created by Dan Federman on 1/27/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import SwiftSyntax
+
+public final class StructVisitor: SyntaxVisitor {
+
+  public init(parentTypeName: String? = nil) {
+    self.parentTypeName = parentTypeName
+  }
+
+  public var structs: [StructInfo] {
+    [structInfo].compactMap { $0 } + innerStructs
+  }
+
+  // TODO: also find and nested classes
+  // TODO: also find and nested enums
+
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+
+    guard !hasFinishedParsingStruct else {
+      assertionFailure("Encountered more than one top-level struct. This is a usage error: a single StructVisitor instance should start walking only over a node of type `StructDeclSyntax`")
+      return .skipChildren
+    }
+
+    if let structInfo = structInfo {
+      // Base case. We've previously found a struct declaration, so this must be an inner struct.
+      // This struct visitor shouldn't recurse down into the children.
+      // Instead, we'll use a new struct visitor to get the information from this struct.
+      let qualifiedParentTypeName: String
+      if let parentTypeName = parentTypeName {
+        qualifiedParentTypeName = "\(parentTypeName).\(structInfo.name)"
+      } else {
+        qualifiedParentTypeName = structInfo.name
+      }
+
+      let innerStructVisitor = StructVisitor(parentTypeName: qualifiedParentTypeName)
+      innerStructVisitor.walk(node)
+
+      self.innerStructs += innerStructVisitor.structs
+      // We've already gotten information from the children from our inner struct visitor.
+      return .skipChildren
+
+    } else {
+      // Recursive case. This is the first struct declaration we've come across.
+      // We need to get its information and then visit children to see if there is more information we need.
+      let name = node.identifier.text
+      let typeInheritanceVisitor = TypeInheritanceVisitor()
+      typeInheritanceVisitor.walk(node)
+
+      structInfo = StructInfo(
+        name: name,
+        inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
+        parentTypeName: parentTypeName)
+      return .visitChildren
+    }
+  }
+
+  public override func visitPost(_ node: StructDeclSyntax) {
+    hasFinishedParsingStruct = node.identifier.text == structInfo?.name
+  }
+
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    if let _ = structInfo {
+      // We've previously found a struct declaration, so this must be an inner class.
+      // TODO: Utilize class visitor to find inner class information, utilizing parent information from structInfo
+    } else {
+      // We've encountered a class declaration before encountering a struct declaration. Something is wrong.
+      assertionFailure("Encountered a top-level class. This is a usage error: a single StructVisitor instance should start walking only over a node of type `StructDeclSyntax`")
+    }
+    return .skipChildren
+  }
+
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    if let _ = structInfo {
+      // We've previously found a struct declaration, so this must be an inner enum.
+      // TODO: Utilize enum visitor to find inner enum information, utilizing parent information from structInfo
+    } else {
+      // We've encountered a class declaration before encountering a struct declaration. Something is wrong.
+      assertionFailure("Encountered a top-level class. This is a usage error: a single StructVisitor instance should start walking only over a node of type `StructDeclSyntax`")
+    }
+    return .skipChildren
+
+  }
+
+  // MARK: Private
+
+  private let parentTypeName: String?
+  private var hasFinishedParsingStruct = false
+  private var structInfo: StructInfo?
+  private var innerStructs = [StructInfo]()
+}
+
+public struct StructInfo: Codable, Equatable {
+  public let name: String
+  public let inheritsFromTypes: [String]
+  public let parentTypeName: String?
+  // TODO: also find and expose properties on a struct
+}

--- a/Sources/SwiftInspectorVisitors/Tests/GenericRequirementVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/GenericRequirementVisitorSpec.swift
@@ -180,10 +180,8 @@ final class GenericRequirementVisitorSpec: QuickSpec {
       context("visiting a syntax tree involving an associatedtype that has one generic constraint") {
         it("finds the generic requirements") {
           let content = """
-            public protocol Test {
-              associatedtype SomeType: SomeProtocol where
-                Element: AnyObject
-            }
+            associatedtype SomeType: SomeProtocol where
+              Element: AnyObject
             """
 
           try VisitorExecutor.walkVisitor(
@@ -200,11 +198,9 @@ final class GenericRequirementVisitorSpec: QuickSpec {
       context("visiting a syntax tree involving an associatedtype that has two generic constraints") {
         beforeEach {
           let content = """
-            public protocol Test {
-              associatedtype SomeType: SomeProtocol where
-                Key: AnyObject,
-                Value == CustomStringConvertible
-            }
+            associatedtype SomeType: SomeProtocol where
+              Key: AnyObject,
+              Value == CustomStringConvertible
             """
 
           try? VisitorExecutor.walkVisitor(
@@ -230,11 +226,8 @@ final class GenericRequirementVisitorSpec: QuickSpec {
       context("visiting a syntax tree involving a contextual where clause that has one generic constraint") {
         it("finds the generic requirements") {
           let content = """
-              extension Array
-              {
-                func print() where Element: CustomStringConvertible {
-                  forEach { print($0) }
-                }
+              func print() where Element: CustomStringConvertible {
+                forEach { print($0) }
               }
               """
 

--- a/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
@@ -1,0 +1,274 @@
+// Created by Dan Federman on 1/26/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Nimble
+import Quick
+import SwiftInspectorTestHelpers
+
+@testable import SwiftInspectorVisitors
+
+final class StructVisitorSpec: QuickSpec {
+  private var sut = StructVisitor()
+
+  override func spec() {
+    beforeEach {
+      self.sut = StructVisitor()
+    }
+
+    describe("visit(_:)") {
+      context("visiting a single struct declaration") {
+        context("with no conformance") {
+          it("finds the type name") {
+            let content = """
+              public struct SomeStruct {}
+              """
+
+            try VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+
+            expect(self.sut.structs.first) == StructInfo(
+              name: "SomeStruct",
+              inheritsFromTypes: [],
+              parentTypeName: nil)
+          }
+        }
+
+        context("with a single type conformance") {
+          it("finds the type name") {
+            let content = """
+              public struct SomeStruct: Equatable {}
+              """
+
+            try VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+
+            expect(self.sut.structs.first) == StructInfo(
+              name: "SomeStruct",
+              inheritsFromTypes: ["Equatable"],
+              parentTypeName: nil)
+          }
+        }
+
+        context("with multiple type conformances") {
+          it("finds the type name") {
+            let content = """
+              public struct SomeStruct: Foo, Bar {}
+              """
+
+            try VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+
+            expect(self.sut.structs.first) == StructInfo(
+              name: "SomeStruct",
+              inheritsFromTypes: ["Foo", "Bar"],
+              parentTypeName: nil)
+          }
+        }
+      }
+
+      context("visiting a code block with nested declarations") {
+        context("visiting a struct with nested structs") {
+          it("finds all nested structs") {
+            let content = """
+              public struct FooStruct {
+                public struct BarFooStruct: Equatable {
+                  public struct BarBarFooStruct: Hashable {}
+                }
+                public struct FooFooStruct {
+                  public struct BarFooFoo1Struct: BarFooFoo1Protocol1,
+                    BarFooFoo1Protocol2
+                  {
+                    public struct BarBarFooFoo1Struct {}
+                  }
+                  public struct BarFooFoo2Struct {}
+                }
+              }
+              """
+
+            try VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+
+            expect(self.sut.structs) == [
+              StructInfo(
+                name: "FooStruct",
+                inheritsFromTypes: [],
+                parentTypeName: nil),
+              StructInfo(
+                name: "BarFooStruct",
+                inheritsFromTypes: ["Equatable"],
+                parentTypeName: "FooStruct"),
+              StructInfo(
+                name: "BarBarFooStruct",
+                inheritsFromTypes: ["Hashable"],
+                parentTypeName: "FooStruct.BarFooStruct"),
+              StructInfo(
+                name: "FooFooStruct",
+                inheritsFromTypes: [],
+                parentTypeName: "FooStruct"),
+              StructInfo(
+                name: "BarFooFoo1Struct",
+                inheritsFromTypes: ["BarFooFoo1Protocol1", "BarFooFoo1Protocol2"],
+                parentTypeName: "FooStruct.FooFooStruct"),
+              StructInfo(
+                name: "BarBarFooFoo1Struct",
+                inheritsFromTypes: [],
+                parentTypeName: "FooStruct.FooFooStruct.BarFooFoo1Struct"),
+              StructInfo(
+                name: "BarFooFoo2Struct",
+                inheritsFromTypes: [],
+                parentTypeName: "FooStruct.FooFooStruct"),
+            ]
+          }
+        }
+
+        context("visiting a struct with nested structs, classes, and enums") {
+          it("finds all nested structs") { // TODO: find classes and enums as well
+            let content = """
+              public struct FooStruct {
+                public class BarFooClass: Equatable {
+                  public struct BarBarFooStruct {} // TODO: find this struct
+                }
+                public enum BarFooEnum {
+                  public struct BarBarFooStruct {} // TODO: find this struct
+                }
+                public struct FooFooStruct {
+                  public struct BarFooFooStruct {}
+                }
+              }
+              """
+
+            try VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+
+            expect(self.sut.structs) == [
+              StructInfo(
+                name: "FooStruct",
+                inheritsFromTypes: [],
+                parentTypeName: nil),
+              StructInfo(
+                name: "FooFooStruct",
+                inheritsFromTypes: [],
+                parentTypeName: "FooStruct"),
+              StructInfo(
+                name: "BarFooFooStruct",
+                inheritsFromTypes: [],
+                parentTypeName: "FooStruct.FooFooStruct"),
+            ]
+          }
+        }
+      }
+
+      context("visiting a code block with multiple top-level declarations") {
+        context("with multiple top-level structs") {
+          it("asserts") {
+            let content = """
+            public struct FooStruct {}
+            public struct BarStruct {}
+            """
+
+            // The StructVisitor is only meant to be used over a single struct.
+            // Using a StructVisitor over a block that has multiple top-level
+            // structs is API misuse.
+            expect(try VisitorExecutor.walkVisitor(
+                    self.sut,
+                    overContent: content))
+              .to(throwAssertion())
+          }
+        }
+
+        context("with a top-level class after a top-level struct") {
+          it("asserts") {
+            let content = """
+            public struct FooStruct {}
+            public struct FooClass {}
+            """
+
+            // The StructVisitor is only meant to be used over a single struct.
+            // Using a StructVisitor over a block that has a top-level class
+            // is API misuse.
+            expect(try VisitorExecutor.walkVisitor(
+                    self.sut,
+                    overContent: content))
+              .to(throwAssertion())
+          }
+        }
+
+        context("with a top-level enum after a top-level struct") {
+          it("asserts") {
+            let content = """
+            public struct FooStruct {}
+            public struct FooEnum {}
+            """
+
+            // The StructVisitor is only meant to be used over a single struct.
+            // Using a StructVisitor over a block that has a top-level enum
+            // is API misuse.
+            expect(try VisitorExecutor.walkVisitor(
+                    self.sut,
+                    overContent: content))
+              .to(throwAssertion())
+          }
+        }
+      }
+
+      context("visiting a code block with a top-level class declaration") {
+        it("asserts") {
+          let content = """
+            public class FooClass {}
+            """
+
+          // The StructVisitor is only meant to be used over a single struct.
+          // Using a StructVisitor over a block that has a top-level class
+          // is API misuse.
+          expect(try VisitorExecutor.walkVisitor(
+                  self.sut,
+                  overContent: content))
+            .to(throwAssertion())
+        }
+      }
+
+      context("visiting a code block with a top-level enum declaration") {
+        it("asserts") {
+          let content = """
+            public enum FooEnum {}
+            """
+
+          // The StructVisitor is only meant to be used over a single struct.
+          // Using a StructVisitor over a block that has a top-level enum
+          // is API misuse.
+          expect(try VisitorExecutor.walkVisitor(
+                  self.sut,
+                  overContent: content))
+            .to(throwAssertion())
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
@@ -93,7 +93,7 @@ final class StructVisitorSpec: QuickSpec {
 
       context("visiting a code block with nested declarations") {
         context("visiting a struct with nested structs") {
-          it("finds all nested structs") {
+          beforeEach {
             let content = """
               public struct FooStruct {
                 public struct BarFooStruct: Equatable {
@@ -110,45 +110,91 @@ final class StructVisitorSpec: QuickSpec {
               }
               """
 
-            try VisitorExecutor.walkVisitor(
+            try? VisitorExecutor.walkVisitor(
               self.sut,
               overContent: content)
+          }
 
-            expect(self.sut.structs) == [
-              StructInfo(
-                name: "FooStruct",
-                inheritsFromTypes: [],
-                parentTypeName: nil),
-              StructInfo(
-                name: "BarFooStruct",
-                inheritsFromTypes: ["Equatable"],
-                parentTypeName: "FooStruct"),
-              StructInfo(
-                name: "BarBarFooStruct",
-                inheritsFromTypes: ["Hashable"],
-                parentTypeName: "FooStruct.BarFooStruct"),
-              StructInfo(
-                name: "FooFooStruct",
-                inheritsFromTypes: [],
-                parentTypeName: "FooStruct"),
-              StructInfo(
-                name: "BarFooFoo1Struct",
-                inheritsFromTypes: ["BarFooFoo1Protocol1", "BarFooFoo1Protocol2"],
-                parentTypeName: "FooStruct.FooFooStruct"),
-              StructInfo(
-                name: "BarBarFooFoo1Struct",
-                inheritsFromTypes: [],
-                parentTypeName: "FooStruct.FooFooStruct.BarFooFoo1Struct"),
-              StructInfo(
-                name: "BarFooFoo2Struct",
-                inheritsFromTypes: [],
-                parentTypeName: "FooStruct.FooFooStruct"),
-            ]
+          it("finds FooStruct") {
+            guard self.sut.structs.count > 0 else {
+              fail("FooStruct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[0]
+            expect(structInfo.name) == "FooStruct"
+            expect(structInfo.inheritsFromTypes) == []
+            expect(structInfo.parentTypeName).to(beNil())
+          }
+
+          it("finds BarFooStruct") {
+            guard self.sut.structs.count > 1 else {
+              fail("BarFooStruct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[1]
+            expect(structInfo.name) == "BarFooStruct"
+            expect(structInfo.inheritsFromTypes) == ["Equatable"]
+            expect(structInfo.parentTypeName) == "FooStruct"
+          }
+
+          it("finds BarBarFooStruct") {
+            guard self.sut.structs.count > 2 else {
+              fail("BarBarFooStruct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[2]
+            expect(structInfo.name) == "BarBarFooStruct"
+            expect(structInfo.inheritsFromTypes) == ["Hashable"]
+            expect(structInfo.parentTypeName) == "FooStruct.BarFooStruct"
+          }
+
+          it("finds FooFooStruct") {
+            guard self.sut.structs.count > 3 else {
+              fail("FooFooStruct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[3]
+            expect(structInfo.name) == "FooFooStruct"
+            expect(structInfo.inheritsFromTypes) == []
+            expect(structInfo.parentTypeName) == "FooStruct"
+          }
+
+          it("finds BarFooFoo1Struct") {
+            guard self.sut.structs.count > 4 else {
+              fail("BarFooFoo1Struct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[4]
+            expect(structInfo.name) == "BarFooFoo1Struct"
+            expect(structInfo.inheritsFromTypes) == ["BarFooFoo1Protocol1", "BarFooFoo1Protocol2"]
+            expect(structInfo.parentTypeName) == "FooStruct.FooFooStruct"
+          }
+
+          it("finds BarBarFooFoo1Struct") {
+            guard self.sut.structs.count > 5 else {
+              fail("BarBarFooFoo1Struct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[5]
+            expect(structInfo.name) == "BarBarFooFoo1Struct"
+            expect(structInfo.inheritsFromTypes) == []
+            expect(structInfo.parentTypeName) == "FooStruct.FooFooStruct.BarFooFoo1Struct"
+          }
+
+          it("finds BarFooFoo2Struct") {
+            guard self.sut.structs.count > 6 else {
+              fail("BarFooFoo2Struct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[6]
+            expect(structInfo.name) == "BarFooFoo2Struct"
+            expect(structInfo.inheritsFromTypes) == []
+            expect(structInfo.parentTypeName) == "FooStruct.FooFooStruct"
           }
         }
 
         context("visiting a struct with nested structs, classes, and enums") {
-          it("finds all nested structs") { // TODO: find classes and enums as well
+          beforeEach { // TODO: find classes and enums as well
             let content = """
               public struct FooStruct {
                 public class BarFooClass: Equatable {
@@ -163,24 +209,42 @@ final class StructVisitorSpec: QuickSpec {
               }
               """
 
-            try VisitorExecutor.walkVisitor(
+            try? VisitorExecutor.walkVisitor(
               self.sut,
               overContent: content)
+          }
 
-            expect(self.sut.structs) == [
-              StructInfo(
-                name: "FooStruct",
-                inheritsFromTypes: [],
-                parentTypeName: nil),
-              StructInfo(
-                name: "FooFooStruct",
-                inheritsFromTypes: [],
-                parentTypeName: "FooStruct"),
-              StructInfo(
-                name: "BarFooFooStruct",
-                inheritsFromTypes: [],
-                parentTypeName: "FooStruct.FooFooStruct"),
-            ]
+          it("finds FooStruct") {
+            guard self.sut.structs.count > 0 else {
+              fail("FooStruct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[0]
+            expect(structInfo.name) == "FooStruct"
+            expect(structInfo.inheritsFromTypes) == []
+            expect(structInfo.parentTypeName).to(beNil())
+          }
+
+          it("finds FooFooStruct") {
+            guard self.sut.structs.count > 1 else {
+              fail("FooFooStruct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[1]
+            expect(structInfo.name) == "FooFooStruct"
+            expect(structInfo.inheritsFromTypes) == []
+            expect(structInfo.parentTypeName) == "FooStruct"
+          }
+
+          it("finds BarFooFooStruct") {
+            guard self.sut.structs.count > 2 else {
+              fail("BarFooFooStruct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[2]
+            expect(structInfo.name) == "BarFooFooStruct"
+            expect(structInfo.inheritsFromTypes) == []
+            expect(structInfo.parentTypeName) == "FooStruct.FooFooStruct"
           }
         }
       }

--- a/Sources/SwiftInspectorVisitors/TypeInheritanceVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/TypeInheritanceVisitor.swift
@@ -31,12 +31,13 @@ public final class TypeInheritanceVisitor: SyntaxVisitor {
 
   public override func visit(_ node: InheritedTypeSyntax) -> SyntaxVisitorContinueKind {
     inheritsFromTypes.append(node.typeName.description.trimmingCharacters(in: .whitespacesAndNewlines))
-    // We care about sibling types but not children
+    // Children don't have any more information about inheritance, so don't visit them.
     return .skipChildren
   }
 
   public override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
-    // We don't care about the internals of this type.
+    // A member declaration block means we've found the body of the type.
+    // There's nothing in this body that would help us determine type inheritance.
     .skipChildren
   }
 }

--- a/Sources/SwiftInspectorVisitors/TypeInheritanceVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/TypeInheritanceVisitor.swift
@@ -31,7 +31,8 @@ public final class TypeInheritanceVisitor: SyntaxVisitor {
 
   public override func visit(_ node: InheritedTypeSyntax) -> SyntaxVisitorContinueKind {
     inheritsFromTypes.append(node.typeName.description.trimmingCharacters(in: .whitespacesAndNewlines))
-    return .visitChildren
+    // We care about sibling types but not children
+    return .skipChildren
   }
 
   public override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {


### PR DESCRIPTION
Best reviewed commit-by-commit. It may be easier to review unit tests before reviewing the shipped code.

Creates a `StructVisitor` in the visitors module. This visitor is capable of determining type information about a struct, as well as finding all of the nested struct definitions within that single struct. This type will get significantly more powerful as we build out a `ClassVisitor` and `EnumVisitor` (see `TODO`s in both tests and code). Both `ClassVisitor` and `EnumVisitor` will look very similar to this visitor, so I'd love to get feedback before continuing to build more of these types.

My current thinking is that this `StructVisitor` will eventually be utilized by a `FileVisitor`.