### PR TITLE
Migrate SyntaxRewriter to use SyntaxVisitor instead

### DIFF
--- a/Sources/SwiftInspectorAnalyzers/StandardAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/StandardAnalyzer.swift
@@ -43,17 +43,6 @@ public struct StandardAnalyzer {
     visitor.walk(syntax)
   }
 
-  /// Analyzes a Swift file with the provide visitor
-  /// - Parameters:
-  ///   - fileURL: The fileURL where the Swift file is located
-  ///   - visitor: A Swift syntax rewriter to use to analyze the provided file
-  /// - Note: Use a visitor when possible. Rewriters should be used to work around this bug: https://bugs.swift.org/browse/SR-11591
-  func analyze(fileURL: URL, withVisitor visitor: SyntaxRewriter) throws
-  {
-    let syntax: SourceFileSyntax = try cachedSyntaxTree.syntaxTree(for: fileURL)
-    _ = visitor.visit(syntax)
-  }
-
   // MARK: Private
 
   private let cachedSyntaxTree: CachedSyntaxTree

--- a/Sources/SwiftInspectorAnalyzers/StaticUsageAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/StaticUsageAnalyzer.swift
@@ -42,7 +42,7 @@ public final class StaticUsageAnalyzer: Analyzer {
     let reader = StaticUsageReader() { [unowned self] node in
       isUsed = isUsed || self.isSyntaxNode(node, ofType: self.staticMember)
     }
-    _ = reader.visit(syntax)
+    reader.walk(syntax)
 
     return StaticUsage(staticMember: self.staticMember, isUsed: isUsed)
   }
@@ -80,15 +80,14 @@ public struct StaticUsage: Equatable {
   public let isUsed: Bool
 }
 
-// TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
-private final class StaticUsageReader: SyntaxRewriter {
+private final class StaticUsageReader: SyntaxVisitor {
   init(onNodeVisit: @escaping (MemberAccessExprSyntax) -> Void) {
     self.onNodeVisit = onNodeVisit
   }
 
-  override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
+  override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
     onNodeVisit(node)
-    return super.visit(node)
+    return .visitChildren
   }
 
   private let onNodeVisit: (MemberAccessExprSyntax) -> Void

--- a/Sources/SwiftInspectorAnalyzers/Tests/StandardAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorAnalyzers/Tests/StandardAnalyzerSpec.swift
@@ -59,23 +59,14 @@ final class StandardAnalyzerSpec: QuickSpec {
         }
         try? Temporary.removeItem(at: fileURL)
       }
-      context("with a visitor") {
-        it("walks the visitor over the content") {
-          let visitor = MockVisitor()
-          try StandardAnalyzer().analyze(fileURL: fileURL, withVisitor: visitor)
 
-          expect(visitor.ifStatementSyntaxVisitCount) == 1
-        }
+      it("walks the visitor over the content") {
+        let visitor = MockVisitor()
+        try StandardAnalyzer().analyze(fileURL: fileURL, withVisitor: visitor)
+
+        expect(visitor.ifStatementSyntaxVisitCount) == 1
       }
 
-      context("with a rewriter") {
-        it("walks the rewriter over the content") {
-          let visitor = MockRewriter()
-          try StandardAnalyzer().analyze(fileURL: fileURL, withVisitor: visitor)
-
-          expect(visitor.ifStatementSyntaxVisitCount) == 1
-        }
-      }
     }
   }
 }

--- a/Sources/SwiftInspectorAnalyzers/TypealiasAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/TypealiasAnalyzer.swift
@@ -41,7 +41,7 @@ public final class TypealiasAnalyzer: Analyzer {
       let statement = self.typealiasStatement(from: node)
       allTypealias.append(statement)
     }
-    _ = reader.visit(syntax)
+    reader.walk(syntax)
 
     return allTypealias
   }
@@ -73,15 +73,14 @@ public final class TypealiasAnalyzer: Analyzer {
   }
 }
 
-// TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
-private final class TypealiasSyntaxReader: SyntaxRewriter {
+private final class TypealiasSyntaxReader: SyntaxVisitor {
   init(onNodeVisit: @escaping (TypealiasDeclSyntax) -> Void) {
     self.onNodeVisit = onNodeVisit
   }
 
-  override func visit(_ node: TypealiasDeclSyntax) -> DeclSyntax {
+  override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
     onNodeVisit(node)
-    return super.visit(node)
+    return .visitChildren
   }
 
   let onNodeVisit: (TypealiasDeclSyntax) -> Void

--- a/Sources/SwiftInspectorTestHelpers/Tests/VisitorExecutorSpec.swift
+++ b/Sources/SwiftInspectorTestHelpers/Tests/VisitorExecutorSpec.swift
@@ -38,32 +38,13 @@ final class VisitorExecutorSpec: QuickSpec {
     }
   }
 
-  private final class MockRewriter: SyntaxRewriter {
-    var ifStatementSyntaxVisitCount = 0
-    override func visit(_ node: IfStmtSyntax) -> StmtSyntax {
-      ifStatementSyntaxVisitCount += 1
-      return super.visit(node)
-    }
-  }
-
   override func spec() {
     describe("walk(:)") {
-      context("with a visitor") {
-        it("walks the visitor over the content") {
-          let visitor = MockVisitor()
-          try VisitorExecutor.walkVisitor(visitor, overContent: "if true {}")
+      it("walks the visitor over the content") {
+        let visitor = MockVisitor()
+        try VisitorExecutor.walkVisitor(visitor, overContent: "if true {}")
 
-          expect(visitor.ifStatementSyntaxVisitCount) == 1
-        }
-      }
-
-      context("with a rewriter") {
-        it("walks the rewriter over the content") {
-          let visitor = MockRewriter()
-          try VisitorExecutor.walkVisitor(visitor, overContent: "if true {}")
-
-          expect(visitor.ifStatementSyntaxVisitCount) == 1
-        }
+        expect(visitor.ifStatementSyntaxVisitCount) == 1
       }
     }
   }

--- a/Sources/SwiftInspectorTestHelpers/VisitorExecutor.swift
+++ b/Sources/SwiftInspectorTestHelpers/VisitorExecutor.swift
@@ -42,21 +42,4 @@ public final class VisitorExecutor {
     visitor.walk(syntax)
     try Temporary.removeItem(at: fileURL)
   }
-
-  /// Walks the provided syntax rewriter along the content's syntax.
-  ///
-  /// - Parameters:
-  ///   - rewriter: The syntax rewriter to walk along the content syntax.
-  ///   - content: The content to turn into source and walk.
-  /// - Note: Use a visitor when possible. Rewriters should be used to work around this bug: https://bugs.swift.org/browse/SR-11591
-  public static func walkVisitor<Rewriter: SyntaxRewriter>(
-    _ rewriter: Rewriter,
-    overContent content: String)
-  throws
-  {
-    let fileURL = try Temporary.makeFile(content: content)
-    let syntax: SourceFileSyntax = try SyntaxParser.parse(fileURL)
-    _ = rewriter.visit(syntax)
-    try Temporary.removeItem(at: fileURL)
-  }
 }

--- a/Sources/SwiftInspectorVisitors/ImportSyntaxReader.swift
+++ b/Sources/SwiftInspectorVisitors/ImportSyntaxReader.swift
@@ -25,14 +25,13 @@
 import Foundation
 import SwiftSyntax
 
-// TODO: Update to use SyntaxVisitor when this bug is resolved (https://bugs.swift.org/browse/SR-11591)
-public final class ImportSyntaxReader: SyntaxRewriter {
+public final class ImportSyntaxReader: SyntaxVisitor {
   public private(set) var imports: [ImportStatement] = []
 
-  public override func visit(_ node: ImportDeclSyntax) -> DeclSyntax {
+  public override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
     let statement = importStatement(from: node)
     imports.append(statement)
-    return super.visit(node)
+    return .visitChildren
   }
 
   private func importStatement(from syntaxNode: ImportDeclSyntax) -> ImportStatement {


### PR DESCRIPTION
When Is started this project I didn't realize I could use the `walk` method to accomplish a similar result than calling `visit` directly. There's an open bug for calling the `visit` method directly.

This PR removes all `SyntaxRewriter` in favor of using `SyntaxVisitor` and the `walk` method instead of `visit`.

This simplifies our reusable code so we don't need to fork so much.