### PR TITLE
Create ClassVisitor

### DIFF
--- a/Sources/SwiftInspectorVisitors/ClassVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ClassVisitor.swift
@@ -79,7 +79,7 @@ public final class ClassVisitor: SyntaxVisitor {
   }
 
   public override func visitPost(_ node: ClassDeclSyntax) {
-    guard !hasFinishedParsingClass else { return true } 
+    guard !hasFinishedParsingClass else { return } 
     hasFinishedParsingClass = node.identifier.text == classInfo?.name
   }
 

--- a/Sources/SwiftInspectorVisitors/ClassVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ClassVisitor.swift
@@ -94,7 +94,7 @@ public final class ClassVisitor: SyntaxVisitor {
       innerStructs += structVisitor.structs
       innerClasses += structVisitor.innerClasses
     } else {
-      // We've encountered a class declaration before encountering a class declaration. Something is wrong.
+      // We've encountered a struct declaration before encountering a class declaration. Something is wrong.
       assertionFailure("Encountered a top-level struct. This is a usage error: a single ClassVisitor instance should start walking only over a node of type `ClassDeclSyntax`")
     }
     return .skipChildren

--- a/Sources/SwiftInspectorVisitors/ClassVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ClassVisitor.swift
@@ -60,7 +60,7 @@ public final class ClassVisitor: SyntaxVisitor {
       innerClassVisitor.walk(node)
 
       self.innerClasses += innerClassVisitor.classes
-      // We've already gotten information from the children from our inner struct visitor.
+      // We've already gotten information from the children from our inner class visitor.
       return .skipChildren
 
     } else {

--- a/Sources/SwiftInspectorVisitors/ClassVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ClassVisitor.swift
@@ -79,6 +79,7 @@ public final class ClassVisitor: SyntaxVisitor {
   }
 
   public override func visitPost(_ node: ClassDeclSyntax) {
+    guard !hasFinishedParsingClass else { return true } 
     hasFinishedParsingClass = node.identifier.text == classInfo?.name
   }
 

--- a/Sources/SwiftInspectorVisitors/ClassVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ClassVisitor.swift
@@ -117,6 +117,12 @@ public final class ClassVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
+  public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+    // We've encountered an extension declaration, which can only be defined at the top-level. Something is wrong.
+    assertionFailure("Encountered an extension. This is a usage error: a single ClassVisitor instance should start walking only over a node of type `ClassDeclSyntax`")
+    return .skipChildren
+  }
+
   // MARK: Private
 
   private let parentTypeName: String?

--- a/Sources/SwiftInspectorVisitors/ClassVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ClassVisitor.swift
@@ -1,0 +1,133 @@
+// Created by Dan Federman on 1/28/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import SwiftSyntax
+
+public final class ClassVisitor: SyntaxVisitor {
+
+  public init(parentTypeName: String? = nil) {
+    self.parentTypeName = parentTypeName
+  }
+
+  /// All of the classes found by this visitor.
+  public var classes: [ClassInfo] {
+    [classInfo].compactMap { $0 } + innerClasses
+  }
+
+  /// Inner structs found by this visitor.
+  public private(set) var innerStructs = [StructInfo]()
+
+  // TODO: also find and nested enums
+
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+
+    guard !hasFinishedParsingClass else {
+      assertionFailure("Encountered more than one top-level class. This is a usage error: a single ClassVisitor instance should start walking only over a node of type `ClassDeclSyntax`")
+      return .skipChildren
+    }
+
+    if let classInfo = classInfo {
+      // Base case. We've previously found a class declaration, so this must be an inner class.
+      // This class visitor shouldn't recurse down into the children.
+      // Instead, we'll use a new class visitor to get the information from this class.
+      let qualifiedParentTypeName = QualifiedParentNameCreator.createNameGiven(
+        currentParentTypeName: parentTypeName,
+        currentTypeName: classInfo.name)
+
+      let innerClassVisitor = ClassVisitor(parentTypeName: qualifiedParentTypeName)
+      innerClassVisitor.walk(node)
+
+      self.innerClasses += innerClassVisitor.classes
+      // We've already gotten information from the children from our inner struct visitor.
+      return .skipChildren
+
+    } else {
+      // Recursive case. This is the first class declaration we've come across.
+      // We need to get its information and then visit children to see if there is more information we need.
+      let name = node.identifier.text
+      let typeInheritanceVisitor = TypeInheritanceVisitor()
+      typeInheritanceVisitor.walk(node)
+
+      classInfo = ClassInfo(
+        name: name,
+        inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
+        parentTypeName: parentTypeName)
+      return .visitChildren
+    }
+  }
+
+  public override func visitPost(_ node: ClassDeclSyntax) {
+    hasFinishedParsingClass = node.identifier.text == classInfo?.name
+  }
+
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    if !hasFinishedParsingClass, let classInfo = classInfo {
+      // We've previously found a class declaration, so this must be an inner struct.
+      let qualifiedParentTypeName = QualifiedParentNameCreator.createNameGiven(
+        currentParentTypeName: parentTypeName,
+        currentTypeName: classInfo.name)
+
+      let structVisitor = StructVisitor(parentTypeName: qualifiedParentTypeName)
+      structVisitor.walk(node)
+      innerStructs += structVisitor.structs
+      innerClasses += structVisitor.innerClasses
+    } else {
+      // We've encountered a class declaration before encountering a class declaration. Something is wrong.
+      assertionFailure("Encountered a top-level struct. This is a usage error: a single ClassVisitor instance should start walking only over a node of type `ClassDeclSyntax`")
+    }
+    return .skipChildren
+  }
+
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    if !hasFinishedParsingClass, let _ = classInfo {
+      // We've previously found a class declaration, so this must be an inner enum.
+      // TODO: Utilize enum visitor to find inner enum information, utilizing parent information from structInfo
+    } else {
+      // We've encountered an enum declaration before encountering a class declaration. Something is wrong.
+      assertionFailure("Encountered a top-level enum. This is a usage error: a single ClassVisitor instance should start walking only over a node of type `ClassDeclSyntax`")
+    }
+    return .skipChildren
+  }
+
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    // We've encountered a protocol declaration, which can only be defined at the top-level. Something is wrong.
+    assertionFailure("Encountered a protocol. This is a usage error: a single ClassVisitor instance should start walking only over a node of type `ClassDeclSyntax`")
+    return .skipChildren
+  }
+
+  // MARK: Private
+
+  private let parentTypeName: String?
+  private var hasFinishedParsingClass = false
+  private var classInfo: ClassInfo?
+  private var innerClasses = [ClassInfo]()
+}
+
+public struct ClassInfo: Codable, Equatable {
+  public let name: String
+  public let inheritsFromTypes: [String]
+  public let parentTypeName: String?
+  // TODO: also find and expose properties on a class
+}

--- a/Sources/SwiftInspectorVisitors/QualifiedParentNameCreator.swift
+++ b/Sources/SwiftInspectorVisitors/QualifiedParentNameCreator.swift
@@ -1,0 +1,39 @@
+// Created by Dan Federman on 1/28/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+struct QualifiedParentNameCreator {
+  static func createNameGiven(
+    currentParentTypeName: String?,
+    currentTypeName: String)
+  -> String
+  {
+    if let currentParentTypeName = currentParentTypeName {
+      return "\(currentParentTypeName).\(currentTypeName)"
+    } else {
+      return currentTypeName
+    }
+  }
+}

--- a/Sources/SwiftInspectorVisitors/QualifiedParentNameCreator.swift
+++ b/Sources/SwiftInspectorVisitors/QualifiedParentNameCreator.swift
@@ -25,6 +25,13 @@
 import Foundation
 
 struct QualifiedParentNameCreator {
+
+  /// Returns a qualified parent name given the current parent type and the just parsed.
+  ///
+  /// - Parameters:
+  ///   - currentParentTypeName: The name of the current parent type.
+  ///   - currentTypeName: The name of the newly parsed type to be added to the parent type.
+  /// - Returns: The fully qualified name given teh current parent type name and the current type name.
   static func createNameGiven(
     currentParentTypeName: String?,
     currentTypeName: String)

--- a/Sources/SwiftInspectorVisitors/StructVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/StructVisitor.swift
@@ -84,7 +84,7 @@ public final class StructVisitor: SyntaxVisitor {
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     if !hasFinishedParsingStruct, let structInfo = structInfo {
-      // We've previously found a struct declaration, so this must be an inner struct.
+      // We've previously found a struct declaration, so this must be an inner class.
       let qualifiedParentTypeName = QualifiedParentNameCreator.createNameGiven(
         currentParentTypeName: parentTypeName,
         currentTypeName: structInfo.name)

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -193,7 +193,7 @@ final class ClassVisitorSpec: QuickSpec {
           }
         }
 
-        context("visiting a struct with nested structs, classes, and enums") {
+        context("visiting a class with nested structs, classes, and enums") {
           beforeEach { // TODO: enums as well
             let content = """
               public class FooClass {

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -1,0 +1,365 @@
+// Created by Dan Federman on 1/26/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Nimble
+import Quick
+import SwiftInspectorTestHelpers
+
+@testable import SwiftInspectorVisitors
+
+final class ClassVisitorSpec: QuickSpec {
+  private var sut = ClassVisitor()
+
+  override func spec() {
+    beforeEach {
+      self.sut = ClassVisitor()
+    }
+
+    describe("visit(_:)") {
+      context("visiting a single class declaration") {
+        context("with no conformance") {
+          it("finds the type name") {
+            let content = """
+              public class SomeClass {}
+              """
+
+            try VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+
+            let classInfo = self.sut.classes.first
+            expect(classInfo?.name) == "SomeClass"
+            expect(classInfo?.inheritsFromTypes) == []
+            expect(classInfo?.parentTypeName).to(beNil())
+          }
+        }
+
+        context("with a single type conformance") {
+          it("finds the type name") {
+            let content = """
+              public class SomeClass: Equatable {}
+              """
+
+            try VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+
+            let classInfo = self.sut.classes.first
+            expect(classInfo?.name) == "SomeClass"
+            expect(classInfo?.inheritsFromTypes) == ["Equatable"]
+            expect(classInfo?.parentTypeName).to(beNil())
+          }
+        }
+
+        context("with multiple type conformances") {
+          it("finds the type name") {
+            let content = """
+              public class SomeClass: Foo, Bar {}
+              """
+
+            try VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+
+            let classInfo = self.sut.classes.first
+            expect(classInfo?.name) == "SomeClass"
+            expect(classInfo?.inheritsFromTypes) == ["Foo", "Bar"]
+            expect(classInfo?.parentTypeName).to(beNil())
+          }
+        }
+      }
+
+      context("visiting a code block with nested declarations") {
+        context("visiting a class with nested classes") {
+          beforeEach {
+            let content = """
+              public class FooClass {
+                public class BarFooClass: Equatable {
+                  public class BarBarFooClass: Hashable {}
+                }
+                public class FooFooClass {
+                  public class BarFooFoo1Class: BarFooFoo1Protocol1,
+                    BarFooFoo1Protocol2
+                  {
+                    public class BarBarFooFoo1Class {}
+                  }
+                  public class BarFooFoo2Class {}
+                }
+              }
+              """
+
+            try? VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+          }
+
+          it("finds FooClass") {
+            guard self.sut.classes.count > 0 else {
+              fail("FooClass not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[0]
+            expect(classInfo.name) == "FooClass"
+            expect(classInfo.inheritsFromTypes) == []
+            expect(classInfo.parentTypeName).to(beNil())
+          }
+
+          it("finds BarFooClass") {
+            guard self.sut.classes.count > 1 else {
+              fail("BarFooClass not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[1]
+            expect(classInfo.name) == "BarFooClass"
+            expect(classInfo.inheritsFromTypes) == ["Equatable"]
+            expect(classInfo.parentTypeName) == "FooClass"
+          }
+
+          it("finds BarBarFooClass") {
+            guard self.sut.classes.count > 2 else {
+              fail("BarBarFooClass not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[2]
+            expect(classInfo.name) == "BarBarFooClass"
+            expect(classInfo.inheritsFromTypes) == ["Hashable"]
+            expect(classInfo.parentTypeName) == "FooClass.BarFooClass"
+          }
+
+          it("finds FooFooClass") {
+            guard self.sut.classes.count > 3 else {
+              fail("FooFooClass not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[3]
+            expect(classInfo.name) == "FooFooClass"
+            expect(classInfo.inheritsFromTypes) == []
+            expect(classInfo.parentTypeName) == "FooClass"
+          }
+
+          it("finds BarFooFoo1Class") {
+            guard self.sut.classes.count > 4 else {
+              fail("BarFooFoo1Class not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[4]
+            expect(classInfo.name) == "BarFooFoo1Class"
+            expect(classInfo.inheritsFromTypes) == ["BarFooFoo1Protocol1", "BarFooFoo1Protocol2"]
+            expect(classInfo.parentTypeName) == "FooClass.FooFooClass"
+          }
+
+          it("finds BarBarFooFoo1Class") {
+            guard self.sut.classes.count > 5 else {
+              fail("BarBarFooFoo1Class not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[5]
+            expect(classInfo.name) == "BarBarFooFoo1Class"
+            expect(classInfo.inheritsFromTypes) == []
+            expect(classInfo.parentTypeName) == "FooClass.FooFooClass.BarFooFoo1Class"
+          }
+
+          it("finds BarFooFoo2Class") {
+            guard self.sut.classes.count > 6 else {
+              fail("BarFooFoo2Class not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[6]
+            expect(classInfo.name) == "BarFooFoo2Class"
+            expect(classInfo.inheritsFromTypes) == []
+            expect(classInfo.parentTypeName) == "FooClass.FooFooClass"
+          }
+        }
+
+        context("visiting a struct with nested structs, classes, and enums") {
+          beforeEach { // TODO: enums as well
+            let content = """
+              public class FooClass {
+                public struct BarFooStruct: Equatable {
+                  public class BarBarFooClass {}
+                }
+                public enum BarFooEnum {
+                  public class BarBarFooClass {} // TODO: find this class
+                }
+                public class FooFooClass {
+                  public class BarFooFooClass {}
+                }
+              }
+              """
+
+            try? VisitorExecutor.walkVisitor(
+              self.sut,
+              overContent: content)
+          }
+
+          it("finds FooClass") {
+            guard self.sut.classes.count > 0 else {
+              fail("FooClass not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[0]
+            expect(classInfo.name) == "FooClass"
+            expect(classInfo.inheritsFromTypes) == []
+            expect(classInfo.parentTypeName).to(beNil())
+          }
+
+          it("finds BarBarFooClass") {
+            guard self.sut.classes.count > 1 else {
+              fail("BarBarFooClass not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[1]
+            expect(classInfo.name) == "BarBarFooClass"
+            expect(classInfo.inheritsFromTypes) == []
+            expect(classInfo.parentTypeName) == "FooClass.BarFooStruct"
+          }
+
+          it("finds FooFooClass") {
+            guard self.sut.classes.count > 2 else {
+              fail("FooFooClass not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[2]
+            expect(classInfo.name) == "FooFooClass"
+            expect(classInfo.inheritsFromTypes) == []
+            expect(classInfo.parentTypeName) == "FooClass"
+          }
+
+          it("finds BarFooFooClass") {
+            guard self.sut.classes.count > 3 else {
+              fail("BarFooFooClass not found at expected index")
+              return
+            }
+            let classInfo = self.sut.classes[3]
+            expect(classInfo.name) == "BarFooFooClass"
+            expect(classInfo.inheritsFromTypes) == []
+            expect(classInfo.parentTypeName) == "FooClass.FooFooClass"
+          }
+        }
+      }
+
+      context("visiting a code block with multiple top-level declarations") {
+        context("with multiple top-level classes") {
+          it("asserts") {
+            let content = """
+            public class FooClass {}
+            public class FooClass {}
+            """
+
+            // The ClassVisitor is only meant to be used over a single struct.
+            // Using a ClassVisitor over a block that has multiple top-level
+            // structs is API misuse.
+            expect(try VisitorExecutor.walkVisitor(
+                    self.sut,
+                    overContent: content))
+              .to(throwAssertion())
+          }
+        }
+
+        context("with a top-level struct after a top-level class") {
+          it("asserts") {
+            let content = """
+            public class FooClass {}
+            public struct FooStruct {}
+            """
+
+            // The ClassVisitor is only meant to be used over a single struct.
+            // Using a ClassVisitor over a block that has a top-level class
+            // is API misuse.
+            expect(try VisitorExecutor.walkVisitor(
+                    self.sut,
+                    overContent: content))
+              .to(throwAssertion())
+          }
+        }
+
+        context("with a top-level enum after a top-level class") {
+          it("asserts") {
+            let content = """
+            public class FooClass {}
+            public struct FooEnum {}
+            """
+
+            // The ClassVisitor is only meant to be used over a single struct.
+            // Using a ClassVisitor over a block that has a top-level enum
+            // is API misuse.
+            expect(try VisitorExecutor.walkVisitor(
+                    self.sut,
+                    overContent: content))
+              .to(throwAssertion())
+          }
+        }
+      }
+
+      context("visiting a code block with a top-level struct declaration") {
+        it("asserts") {
+          let content = """
+            public struct FooStruct {}
+            """
+
+          // The ClassVisitor is only meant to be used over a single struct.
+          // Using a ClassVisitor over a block that has a top-level class
+          // is API misuse.
+          expect(try VisitorExecutor.walkVisitor(
+                  self.sut,
+                  overContent: content))
+            .to(throwAssertion())
+        }
+      }
+
+      context("visiting a code block with a top-level enum declaration") {
+        it("asserts") {
+          let content = """
+            public enum FooEnum {}
+            """
+
+          // The ClassVisitor is only meant to be used over a single struct.
+          // Using a ClassVisitor over a block that has a top-level enum
+          // is API misuse.
+          expect(try VisitorExecutor.walkVisitor(
+                  self.sut,
+                  overContent: content))
+            .to(throwAssertion())
+        }
+      }
+
+      context("visiting a code block with a protocol declaration") {
+        it("asserts") {
+          let content = """
+            public protocol FooProtocol {}
+            """
+
+          // The ClassVisitor is only meant to be used over a single struct.
+          // Using a ClassVisitor over a block that has a top-level enum
+          // is API misuse.
+          expect(try VisitorExecutor.walkVisitor(
+                  self.sut,
+                  overContent: content))
+            .to(throwAssertion())
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -116,80 +116,73 @@ final class ClassVisitorSpec: QuickSpec {
           }
 
           it("finds FooClass") {
-            guard self.sut.classes.count > 0 else {
-              fail("FooClass not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "FooClass"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == nil
             }
-            let classInfo = self.sut.classes[0]
-            expect(classInfo.name) == "FooClass"
-            expect(classInfo.inheritsFromTypes) == []
-            expect(classInfo.parentTypeName).to(beNil())
+
+            expect(matching.count) == 1
           }
 
           it("finds BarFooClass") {
-            guard self.sut.classes.count > 1 else {
-              fail("BarFooClass not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "BarFooClass"
+                && $0.inheritsFromTypes == ["Equatable"]
+                && $0.parentTypeName == "FooClass"
             }
-            let classInfo = self.sut.classes[1]
-            expect(classInfo.name) == "BarFooClass"
-            expect(classInfo.inheritsFromTypes) == ["Equatable"]
-            expect(classInfo.parentTypeName) == "FooClass"
+
+            expect(matching.count) == 1
           }
 
           it("finds BarBarFooClass") {
-            guard self.sut.classes.count > 2 else {
-              fail("BarBarFooClass not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "BarBarFooClass"
+                && $0.inheritsFromTypes == ["Hashable"]
+                && $0.parentTypeName == "FooClass.BarFooClass"
             }
-            let classInfo = self.sut.classes[2]
-            expect(classInfo.name) == "BarBarFooClass"
-            expect(classInfo.inheritsFromTypes) == ["Hashable"]
-            expect(classInfo.parentTypeName) == "FooClass.BarFooClass"
+
+            expect(matching.count) == 1
           }
 
           it("finds FooFooClass") {
-            guard self.sut.classes.count > 3 else {
-              fail("FooFooClass not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "FooFooClass"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooClass"
             }
-            let classInfo = self.sut.classes[3]
-            expect(classInfo.name) == "FooFooClass"
-            expect(classInfo.inheritsFromTypes) == []
-            expect(classInfo.parentTypeName) == "FooClass"
+
+            expect(matching.count) == 1
           }
 
           it("finds BarFooFoo1Class") {
-            guard self.sut.classes.count > 4 else {
-              fail("BarFooFoo1Class not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "BarFooFoo1Class"
+                && $0.inheritsFromTypes == ["BarFooFoo1Protocol1", "BarFooFoo1Protocol2"]
+                && $0.parentTypeName == "FooClass.FooFooClass"
             }
-            let classInfo = self.sut.classes[4]
-            expect(classInfo.name) == "BarFooFoo1Class"
-            expect(classInfo.inheritsFromTypes) == ["BarFooFoo1Protocol1", "BarFooFoo1Protocol2"]
-            expect(classInfo.parentTypeName) == "FooClass.FooFooClass"
+
+            expect(matching.count) == 1
           }
 
           it("finds BarBarFooFoo1Class") {
-            guard self.sut.classes.count > 5 else {
-              fail("BarBarFooFoo1Class not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "BarBarFooFoo1Class"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooClass.FooFooClass.BarFooFoo1Class"
             }
-            let classInfo = self.sut.classes[5]
-            expect(classInfo.name) == "BarBarFooFoo1Class"
-            expect(classInfo.inheritsFromTypes) == []
-            expect(classInfo.parentTypeName) == "FooClass.FooFooClass.BarFooFoo1Class"
+
+            expect(matching.count) == 1
           }
 
           it("finds BarFooFoo2Class") {
-            guard self.sut.classes.count > 6 else {
-              fail("BarFooFoo2Class not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "BarFooFoo2Class"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooClass.FooFooClass"
             }
-            let classInfo = self.sut.classes[6]
-            expect(classInfo.name) == "BarFooFoo2Class"
-            expect(classInfo.inheritsFromTypes) == []
-            expect(classInfo.parentTypeName) == "FooClass.FooFooClass"
+
+            expect(matching.count) == 1
           }
         }
 
@@ -215,47 +208,43 @@ final class ClassVisitorSpec: QuickSpec {
           }
 
           it("finds FooClass") {
-            guard self.sut.classes.count > 0 else {
-              fail("FooClass not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "FooClass"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == nil
             }
-            let classInfo = self.sut.classes[0]
-            expect(classInfo.name) == "FooClass"
-            expect(classInfo.inheritsFromTypes) == []
-            expect(classInfo.parentTypeName).to(beNil())
+
+            expect(matching.count) == 1
           }
 
           it("finds BarBarFooClass") {
-            guard self.sut.classes.count > 1 else {
-              fail("BarBarFooClass not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "BarBarFooClass"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooClass.BarFooStruct"
             }
-            let classInfo = self.sut.classes[1]
-            expect(classInfo.name) == "BarBarFooClass"
-            expect(classInfo.inheritsFromTypes) == []
-            expect(classInfo.parentTypeName) == "FooClass.BarFooStruct"
+
+            expect(matching.count) == 1
           }
 
           it("finds FooFooClass") {
-            guard self.sut.classes.count > 2 else {
-              fail("FooFooClass not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "FooFooClass"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooClass"
             }
-            let classInfo = self.sut.classes[2]
-            expect(classInfo.name) == "FooFooClass"
-            expect(classInfo.inheritsFromTypes) == []
-            expect(classInfo.parentTypeName) == "FooClass"
+
+            expect(matching.count) == 1
           }
 
           it("finds BarFooFooClass") {
-            guard self.sut.classes.count > 3 else {
-              fail("BarFooFooClass not found at expected index")
-              return
+            let matching = self.sut.classes.filter {
+              $0.name == "BarFooFooClass"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooClass.FooFooClass"
             }
-            let classInfo = self.sut.classes[3]
-            expect(classInfo.name) == "BarFooFooClass"
-            expect(classInfo.inheritsFromTypes) == []
-            expect(classInfo.parentTypeName) == "FooClass.FooFooClass"
+
+            expect(matching.count) == 1
           }
         }
       }

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -268,9 +268,9 @@ final class ClassVisitorSpec: QuickSpec {
             public class FooClass {}
             """
 
-            // The ClassVisitor is only meant to be used over a single struct.
+            // The ClassVisitor is only meant to be used over a single class.
             // Using a ClassVisitor over a block that has multiple top-level
-            // structs is API misuse.
+            // classes is API misuse.
             expect(try VisitorExecutor.walkVisitor(
                     self.sut,
                     overContent: content))
@@ -285,8 +285,8 @@ final class ClassVisitorSpec: QuickSpec {
             public struct FooStruct {}
             """
 
-            // The ClassVisitor is only meant to be used over a single struct.
-            // Using a ClassVisitor over a block that has a top-level class
+            // The ClassVisitor is only meant to be used over a single class.
+            // Using a ClassVisitor over a block that has a top-level struct
             // is API misuse.
             expect(try VisitorExecutor.walkVisitor(
                     self.sut,
@@ -302,7 +302,7 @@ final class ClassVisitorSpec: QuickSpec {
             public struct FooEnum {}
             """
 
-            // The ClassVisitor is only meant to be used over a single struct.
+            // The ClassVisitor is only meant to be used over a single class.
             // Using a ClassVisitor over a block that has a top-level enum
             // is API misuse.
             expect(try VisitorExecutor.walkVisitor(
@@ -319,7 +319,7 @@ final class ClassVisitorSpec: QuickSpec {
             public struct FooStruct {}
             """
 
-          // The ClassVisitor is only meant to be used over a single struct.
+          // The ClassVisitor is only meant to be used over a single class.
           // Using a ClassVisitor over a block that has a top-level class
           // is API misuse.
           expect(try VisitorExecutor.walkVisitor(
@@ -335,7 +335,7 @@ final class ClassVisitorSpec: QuickSpec {
             public enum FooEnum {}
             """
 
-          // The ClassVisitor is only meant to be used over a single struct.
+          // The ClassVisitor is only meant to be used over a single class.
           // Using a ClassVisitor over a block that has a top-level enum
           // is API misuse.
           expect(try VisitorExecutor.walkVisitor(
@@ -351,7 +351,7 @@ final class ClassVisitorSpec: QuickSpec {
             public protocol FooProtocol {}
             """
 
-          // The ClassVisitor is only meant to be used over a single struct.
+          // The ClassVisitor is only meant to be used over a single class.
           // Using a ClassVisitor over a block that has a top-level enum
           // is API misuse.
           expect(try VisitorExecutor.walkVisitor(

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -320,7 +320,7 @@ final class ClassVisitorSpec: QuickSpec {
             """
 
           // The ClassVisitor is only meant to be used over a single class.
-          // Using a ClassVisitor over a block that has a top-level class
+          // Using a ClassVisitor over a block that has a top-level struct
           // is API misuse.
           expect(try VisitorExecutor.walkVisitor(
                   self.sut,
@@ -352,7 +352,7 @@ final class ClassVisitorSpec: QuickSpec {
             """
 
           // The ClassVisitor is only meant to be used over a single class.
-          // Using a ClassVisitor over a block that has a top-level enum
+          // Using a ClassVisitor over a block that has a protocol
           // is API misuse.
           expect(try VisitorExecutor.walkVisitor(
                   self.sut,

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -360,6 +360,22 @@ final class ClassVisitorSpec: QuickSpec {
             .to(throwAssertion())
         }
       }
+
+      context("visiting a code block with an extension declaration") {
+        it("asserts") {
+          let content = """
+            public extension Array {}
+            """
+
+          // The ClassVisitor is only meant to be used over a single class.
+          // Using a ClassVisitor over a block that has an extension
+          // is API misuse.
+          expect(try VisitorExecutor.walkVisitor(
+                  self.sut,
+                  overContent: content))
+            .to(throwAssertion())
+        }
+      }
     }
   }
 }

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -265,7 +265,7 @@ final class ClassVisitorSpec: QuickSpec {
           it("asserts") {
             let content = """
             public class FooClass {}
-            public class FooClass {}
+            public class BarClass {}
             """
 
             // The ClassVisitor is only meant to be used over a single class.

--- a/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
@@ -194,11 +194,11 @@ final class StructVisitorSpec: QuickSpec {
         }
 
         context("visiting a struct with nested structs, classes, and enums") {
-          beforeEach { // TODO: find classes and enums as well
+          beforeEach { // TODO: enums as well
             let content = """
               public struct FooStruct {
                 public class BarFooClass: Equatable {
-                  public struct BarBarFooStruct {} // TODO: find this struct
+                  public struct BarBarFooStruct {}
                 }
                 public enum BarFooEnum {
                   public struct BarBarFooStruct {} // TODO: find this struct
@@ -225,23 +225,34 @@ final class StructVisitorSpec: QuickSpec {
             expect(structInfo.parentTypeName).to(beNil())
           }
 
-          it("finds FooFooStruct") {
+          it("finds BarBarFooStruct") {
             guard self.sut.structs.count > 1 else {
-              fail("FooFooStruct not found at expected index")
+              fail("BarBarFooStruct not found at expected index")
               return
             }
             let structInfo = self.sut.structs[1]
+            expect(structInfo.name) == "BarBarFooStruct"
+            expect(structInfo.inheritsFromTypes) == []
+            expect(structInfo.parentTypeName) == "FooStruct.BarFooClass"
+          }
+
+          it("finds FooFooStruct") {
+            guard self.sut.structs.count > 2 else {
+              fail("FooFooStruct not found at expected index")
+              return
+            }
+            let structInfo = self.sut.structs[2]
             expect(structInfo.name) == "FooFooStruct"
             expect(structInfo.inheritsFromTypes) == []
             expect(structInfo.parentTypeName) == "FooStruct"
           }
 
           it("finds BarFooFooStruct") {
-            guard self.sut.structs.count > 2 else {
+            guard self.sut.structs.count > 3 else {
               fail("BarFooFooStruct not found at expected index")
               return
             }
-            let structInfo = self.sut.structs[2]
+            let structInfo = self.sut.structs[3]
             expect(structInfo.name) == "BarFooFooStruct"
             expect(structInfo.inheritsFromTypes) == []
             expect(structInfo.parentTypeName) == "FooStruct.FooFooStruct"
@@ -271,7 +282,7 @@ final class StructVisitorSpec: QuickSpec {
           it("asserts") {
             let content = """
             public struct FooStruct {}
-            public struct FooClass {}
+            public class FooClass {}
             """
 
             // The StructVisitor is only meant to be used over a single struct.


### PR DESCRIPTION
Creates a `ClassVisitor` in the visitors module. This visitor is capable of determining type information about a class. While I was here, I updated the `StructVisitor` to be able to gather information about classes defined within a struct.