### PR TITLE
Create FileVisitor

### DIFF
--- a/Sources/SwiftInspectorAnalyzers/ImportsAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/ImportsAnalyzer.swift
@@ -28,7 +28,7 @@ import SwiftInspectorVisitors
 extension StandardAnalyzer {
 
   public func analyzeImports(fileURL: URL) throws -> [ImportStatement] {
-    let visitor = ImportSyntaxReader()
+    let visitor = ImportVisitor()
     try analyze(fileURL: fileURL, withVisitor: visitor)
     return visitor.imports
   }

--- a/Sources/SwiftInspectorVisitors/FileVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FileVisitor.swift
@@ -1,0 +1,108 @@
+// Created by Dan Federman on 1/28/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import SwiftSyntax
+
+public final class FileVisitor: SyntaxVisitor {
+
+  public init(fileURL: URL) {
+    fileInfo = FileInfo(url: fileURL)
+  }
+
+  public private(set) var fileInfo: FileInfo
+
+  public override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
+    let importVisitor = ImportVisitor()
+    importVisitor.walk(node)
+
+    fileInfo.appendImports(importVisitor.imports)
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    let protocolVisitor = ProtocolVisitor()
+    protocolVisitor.walk(node)
+
+    if let protocolInfo = protocolVisitor.protocolInfo {
+      fileInfo.appendProtocol(protocolInfo)
+    }
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    let structVisitor = StructVisitor()
+    structVisitor.walk(node)
+
+    fileInfo.appendStructs(structVisitor.structs)
+    // TODO: append classes
+    // TODO: append enums
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    // TODO: find an append classes
+    // TODO: append structs
+    // TODO: append enums
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    // TODO: find an append enums
+    // TODO: append structs
+    // TODO: append classes
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
+  // MARK: Private
+
+  private var hasFinishedParsingProtocol = false
+}
+
+public struct FileInfo: Codable, Equatable {
+  public let url: URL
+  public private(set) var imports = [ImportStatement]()
+  public private(set) var protocols = [ProtocolInfo]()
+  public private(set) var structs = [StructInfo]()
+  // TODO: also find classes and enums
+
+  mutating func appendImports(_ imports: [ImportStatement]) {
+    self.imports.append(contentsOf: imports)
+  }
+  mutating func appendProtocol(_ protocolInfo: ProtocolInfo) {
+    protocols.append(protocolInfo)
+  }
+  mutating func appendStructs(_ structs: [StructInfo]) {
+    self.structs.append(contentsOf: structs)
+  }
+}

--- a/Sources/SwiftInspectorVisitors/FileVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FileVisitor.swift
@@ -83,10 +83,6 @@ public final class FileVisitor: SyntaxVisitor {
     // We don't need to visit children because our visitor just did that for us.
     return .skipChildren
   }
-
-  // MARK: Private
-
-  private var hasFinishedParsingProtocol = false
 }
 
 public struct FileInfo: Codable, Equatable {

--- a/Sources/SwiftInspectorVisitors/ImportVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ImportVisitor.swift
@@ -25,13 +25,33 @@
 import Foundation
 import SwiftSyntax
 
-public final class ImportSyntaxReader: SyntaxVisitor {
+public final class ImportVisitor: SyntaxVisitor {
   public private(set) var imports: [ImportStatement] = []
 
   public override func visit(_ node: ImportDeclSyntax) -> SyntaxVisitorContinueKind {
     let statement = importStatement(from: node)
     imports.append(statement)
     return .visitChildren
+  }
+
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    // We don't need to visit children because this code can't have imports.
+    return .skipChildren
+  }
+
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    // We don't need to visit children because this code can't have imports.
+    return .skipChildren
+  }
+
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    // We don't need to visit children because this code can't have imports.
+    return .skipChildren
+  }
+
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    // We don't need to visit children because this code can't have imports.
+    return .skipChildren
   }
 
   private func importStatement(from syntaxNode: ImportDeclSyntax) -> ImportStatement {

--- a/Sources/SwiftInspectorVisitors/ImportVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ImportVisitor.swift
@@ -36,22 +36,22 @@ public final class ImportVisitor: SyntaxVisitor {
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     // We don't need to visit children because this code can't have imports.
-    return .skipChildren
+    .skipChildren
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     // We don't need to visit children because this code can't have imports.
-    return .skipChildren
+    .skipChildren
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     // We don't need to visit children because this code can't have imports.
-    return .skipChildren
+    .skipChildren
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
     // We don't need to visit children because this code can't have imports.
-    return .skipChildren
+    .skipChildren
   }
 
   private func importStatement(from syntaxNode: ImportDeclSyntax) -> ImportStatement {

--- a/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
@@ -1,0 +1,111 @@
+// Created by Dan Federman on 1/28/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Nimble
+import Quick
+import SwiftInspectorTestHelpers
+
+@testable import SwiftInspectorVisitors
+
+final class FileVisitorSpec: QuickSpec {
+  private var sut = FileVisitor(fileURL: URL(fileURLWithPath: #filePath))
+
+  override func spec() {
+    beforeEach {
+      self.sut = FileVisitor(fileURL: URL(fileURLWithPath: #filePath))
+    }
+
+    describe("visit(_:)") {
+      context("file with nested types") {
+        beforeEach {
+          let content = """
+              import Foundation
+
+              struct TestStruct {
+                struct InnerStruct {}
+                // TODO: find this definition
+                class InnerClass {}
+                // TODO: find this definition
+                enum InnerEnum {}
+              }
+
+              // TODO: find this definition and inner definitions
+              class TestClass {
+                struct InnerStruct {}
+                class InnerClass {}
+                enum InnerEnum {}
+              }
+
+              // TODO: find this definition and inner definitions
+              enum TestEnum {
+                struct InnerStruct {}
+                class InnerClass {}
+                enum InnerEnum {}
+              }
+
+              protocol TestProtocol {}
+
+              // TODO: find this definition and inner definitions.
+              // TODO: find and propogate this generic constraint to inner types.
+              extension Array where Element == Int {
+                struct InnerStruct {}
+                class InnerClass {}
+                enum InnerEnum {}
+              }
+              """
+
+          try? VisitorExecutor.walkVisitor(
+            self.sut,
+            overContent: content)
+        }
+
+        it("finds the import") {
+          expect(self.sut.fileInfo.imports.count) == 1
+          expect(self.sut.fileInfo.imports.first?.mainModule) == "Foundation"
+        }
+
+        it("finds TestStruct") {
+          let matchingStructs = self.sut.fileInfo.structs.filter { $0.name == "TestStruct" }
+          expect(matchingStructs.count) == 1
+        }
+
+        it("finds TestStruct.InnerStruct") {
+          let matchingStructs = self.sut.fileInfo.structs.filter {
+            $0.name == "InnerStruct"
+              && $0.parentTypeName == "TestStruct"
+          }
+          expect(matchingStructs.count) == 1
+        }
+
+        it("finds TestProtocol") {
+          let matchingStructs = self.sut.fileInfo.protocols.filter {
+            $0.name == "TestProtocol"
+          }
+          expect(matchingStructs.count) == 1
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwiftInspectorVisitors/Tests/ImportVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ImportVisitorSpec.swift
@@ -29,12 +29,12 @@ import SwiftInspectorTestHelpers
 
 @testable import SwiftInspectorVisitors
 
-final class ImportSyntaxReaderSpec: QuickSpec {
-  private var sut = ImportSyntaxReader()
+final class ImportVisitorSpec: QuickSpec {
+  private var sut = ImportVisitor()
 
   override func spec() {
     beforeEach {
-      self.sut = ImportSyntaxReader()
+      self.sut = ImportVisitor()
     }
 
     describe("visit") {

--- a/Sources/SwiftInspectorVisitors/Tests/ImportVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ImportVisitorSpec.swift
@@ -80,12 +80,12 @@ final class ImportVisitorSpec: QuickSpec {
 
       }
 
-      context("with an  import statement with an attribute") {
+      context("with an import statement with an attribute") {
         beforeEach {
           let content = """
                         @_export import SomeModule
 
-                        public final class Some {}
+                        public final protocol Some {}
                         """
           try? VisitorExecutor.walkVisitor(
             self.sut,
@@ -102,8 +102,7 @@ final class ImportVisitorSpec: QuickSpec {
           let content = """
                         import SomeModule.Submodule
 
-                        public final class Some {
-                        }
+                        public final struct Some {}
                         """
           try? VisitorExecutor.walkVisitor(
             self.sut,
@@ -129,8 +128,7 @@ final class ImportVisitorSpec: QuickSpec {
           let content = """
                         import struct SomeModule.Submodule
 
-                        public final class Some {
-                        }
+                        public final enum Some {}
                         """
           try? VisitorExecutor.walkVisitor(
             self.sut,
@@ -157,8 +155,7 @@ final class ImportVisitorSpec: QuickSpec {
                         import struct SomeModule.Submodule
                         import class Another.AnotherSubmodule
 
-                        public final class Some {
-                        }
+                        public final class Some {}
                         """
           try? VisitorExecutor.walkVisitor(
             self.sut,


### PR DESCRIPTION
Creates a `FileVisitor` in the visitors module. This visitor is capable of determining type information about a file. I'll continue building out this file as I add more visitor types.

While I was here I renamed `ImportSyntaxReader` -> `ImportVisitor` now that #57 changed the inherited type. Consistency!