### PR TITLE
Enable FileVisitor to find all types

### DIFF
--- a/Sources/SwiftInspectorAnalyzers/Tests/StaticUsageAnalyzerSpec.swift
+++ b/Sources/SwiftInspectorAnalyzers/Tests/StaticUsageAnalyzerSpec.swift
@@ -184,7 +184,6 @@ final class StaticUsageAnalyzerSpec: QuickSpec {
         let content = """
         JitneyProducer.shared.publish(
               PaidGrowth.V1.PaidGrowthSignupCompletePixelEvent(
-                // TODO: Use the globalLoggingContext property on an injected LoggingService than accessing a singleton directly.
                 context: EventContext.shared.loggingContext(),
                 device_id: trackingManager.value(forAirEventsSharedKey: deviceIDParamKey) ?? "",
                 user_id: Int64(accountManager.activeAccount?.user.userId ?? "") ?? 0

--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -67,9 +67,9 @@ public final class ExtensionVisitor: SyntaxVisitor {
       let classVisitor = ClassVisitor(parentTypeName: extensionInfo.name)
       classVisitor.walk(node)
 
-      innerClasses.append(contentsOf: classVisitor.classes)
-      innerStructs.append(contentsOf: classVisitor.innerStructs)
-      innerEnums.append(contentsOf: classVisitor.innerEnums)
+      innerClasses += classVisitor.classes
+      innerStructs += classVisitor.innerStructs
+      innerEnums += classVisitor.innerEnums
 
     } else {
       // We've encountered a class declaration before encountering an extension declaration. Something is wrong.
@@ -84,9 +84,9 @@ public final class ExtensionVisitor: SyntaxVisitor {
       let structVisitor = StructVisitor(parentTypeName: extensionInfo.name)
       structVisitor.walk(node)
 
-      innerStructs.append(contentsOf: structVisitor.structs)
-      innerClasses.append(contentsOf: structVisitor.innerClasses)
-      innerEnums.append(contentsOf: structVisitor.innerEnums)
+      innerStructs += structVisitor.structs
+      innerClasses += structVisitor.innerClasses
+      innerEnums += structVisitor.innerEnums
 
     } else {
       // We've encountered a class declaration before encountering an extension declaration. Something is wrong.
@@ -102,9 +102,9 @@ public final class ExtensionVisitor: SyntaxVisitor {
       let enumVisitor = EnumVisitor(parentTypeName: extensionInfo.name)
       enumVisitor.walk(node)
 
-      innerEnums.append(contentsOf: enumVisitor.enums)
-      innerStructs.append(contentsOf: enumVisitor.innerStructs)
-      innerClasses.append(contentsOf: enumVisitor.innerClasses)
+      innerEnums += enumVisitor.enums
+      innerStructs += enumVisitor.innerStructs
+      innerClasses += enumVisitor.innerClasses
 
     } else {
       // We've encountered a enum declaration before encountering an extension declaration. Something is wrong.

--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -29,10 +29,12 @@ public final class ExtensionVisitor: SyntaxVisitor {
 
   /// The extension found by this visitor.
   public private(set) var extensionInfo: ExtensionInfo?
-  public private(set) var structs = [StructInfo]()
-
-  // TODO: also find and nested classes
-  // TODO: also find and nested enums
+  /// Inner structs found by this visitor.
+  public private(set) var innerStructs = [StructInfo]()
+  /// Inner classes found by this visitor.
+  public private(set) var innerClasses = [ClassInfo]()
+  /// Inner enums found by this visitor.
+  public private(set) var innerEnums = [EnumInfo]()
 
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
 
@@ -51,8 +53,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
     extensionInfo = ExtensionInfo(
       name: name,
       inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
-      genericRequirements: genericRequirementsVisitor.genericRequirements,
-      innerStructs: [])
+      genericRequirements: genericRequirementsVisitor.genericRequirements)
     return .visitChildren
   }
 
@@ -61,9 +62,15 @@ public final class ExtensionVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    if !hasFinishedParsingExtension, let _ = extensionInfo {
+    if !hasFinishedParsingExtension, let extensionInfo = extensionInfo {
       // We've previously found an extension declaration, so this must be an inner class.
-      // TODO: Utilize class visitor to find inner class information, utilizing parent information from extensionInfo
+      let classVisitor = ClassVisitor(parentTypeName: extensionInfo.name)
+      classVisitor.walk(node)
+
+      innerClasses.append(contentsOf: classVisitor.classes)
+      innerStructs.append(contentsOf: classVisitor.innerStructs)
+      innerEnums.append(contentsOf: classVisitor.innerEnums)
+
     } else {
       // We've encountered a class declaration before encountering an extension declaration. Something is wrong.
       assertionFailure("Encountered a top-level class. This is a usage error: a single ExtensionVisitor instance should start walking only over a node of type `ExtensionDeclSyntax`")
@@ -77,7 +84,9 @@ public final class ExtensionVisitor: SyntaxVisitor {
       let structVisitor = StructVisitor(parentTypeName: extensionInfo.name)
       structVisitor.walk(node)
 
-      structs.append(contentsOf: structVisitor.structs)
+      innerStructs.append(contentsOf: structVisitor.structs)
+      innerClasses.append(contentsOf: structVisitor.innerClasses)
+      innerEnums.append(contentsOf: structVisitor.innerEnums)
 
     } else {
       // We've encountered a class declaration before encountering an extension declaration. Something is wrong.
@@ -88,9 +97,15 @@ public final class ExtensionVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    if !hasFinishedParsingExtension, let _ = extensionInfo {
+    if !hasFinishedParsingExtension, let extensionInfo = extensionInfo {
       // We've previously found a extension declaration, so this must be an inner enum.
-      // TODO: Utilize enum visitor to find inner enum information, utilizing parent information from extensionInfo
+      let enumVisitor = EnumVisitor(parentTypeName: extensionInfo.name)
+      enumVisitor.walk(node)
+
+      innerEnums.append(contentsOf: enumVisitor.enums)
+      innerStructs.append(contentsOf: enumVisitor.innerStructs)
+      innerClasses.append(contentsOf: enumVisitor.innerClasses)
+
     } else {
       // We've encountered a enum declaration before encountering an extension declaration. Something is wrong.
       assertionFailure("Encountered a top-level enum. This is a usage error: a single ExtensionVisitor instance should start walking only over a node of type `ExtensionDeclSyntax`")
@@ -113,8 +128,5 @@ public struct ExtensionInfo: Codable, Equatable {
   public let name: String
   public private(set) var inheritsFromTypes: [String]
   public private(set) var genericRequirements: [GenericRequirement]
-  public private(set) var innerStructs: [StructInfo]
-  // TODO: Also find and expose inner classes
-  // TODO: Also find and expose inner enums
   // TODO: also find and expose computed properties
 }

--- a/Sources/SwiftInspectorVisitors/FileVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FileVisitor.swift
@@ -116,19 +116,19 @@ public struct FileInfo: Codable, Equatable {
   public private(set) var extensions = [ExtensionInfo]()
 
   mutating func appendImports(_ imports: [ImportStatement]) {
-    self.imports.append(contentsOf: imports)
+    self.imports += imports
   }
   mutating func appendProtocol(_ protocolInfo: ProtocolInfo) {
     protocols.append(protocolInfo)
   }
   mutating func appendStructs(_ structs: [StructInfo]) {
-    self.structs.append(contentsOf: structs)
+    self.structs += structs
   }
   mutating func appendClasses(_ classes: [ClassInfo]) {
-    self.classes.append(contentsOf: classes)
+    self.classes += classes
   }
   mutating func appendEnums(_ enums: [EnumInfo]) {
-    self.enums.append(contentsOf: enums)
+    self.enums += enums
   }
   mutating func appendExtension(_ extensionInfo: ExtensionInfo) {
     extensions.append(extensionInfo)

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -187,14 +187,14 @@ final class ClassVisitorSpec: QuickSpec {
         }
 
         context("visiting a class with nested structs, classes, and enums") {
-          beforeEach { // TODO: enums as well
+          beforeEach {
             let content = """
               public class FooClass {
                 public struct BarFooStruct: Equatable {
                   public class BarBarFooClass {}
                 }
                 public enum BarFooEnum {
-                  public class BarBarFooClass {} // TODO: find this class
+                  public class BarBarFooClass {}
                 }
                 public class FooFooClass {
                   public class BarFooFooClass {}
@@ -242,6 +242,26 @@ final class ClassVisitorSpec: QuickSpec {
               $0.name == "BarFooFooClass"
                 && $0.inheritsFromTypes == []
                 && $0.parentTypeName == "FooClass.FooFooClass"
+            }
+
+            expect(matching.count) == 1
+          }
+
+          it("finds BarFooEnum") {
+            let matching = self.sut.innerEnums.filter {
+              $0.name == "BarFooEnum"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooClass"
+            }
+
+            expect(matching.count) == 1
+          }
+
+          it("finds BarBarFooClass") {
+            let matching = self.sut.classes.filter {
+              $0.name == "BarBarFooClass"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooClass.BarFooEnum"
             }
 
             expect(matching.count) == 1

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -217,7 +217,17 @@ final class ClassVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarBarFooClass") {
+          it("finds FooClass.BarFooStruct") {
+            let matching = self.sut.innerStructs.filter {
+              $0.name == "BarFooStruct"
+                && $0.inheritsFromTypes == ["Equatable"]
+                && $0.parentTypeName == "FooClass"
+            }
+
+            expect(matching.count) == 1
+          }
+
+          it("finds FooClass.BarFooStruct.BarBarFooClass") {
             let matching = self.sut.classes.filter {
               $0.name == "BarBarFooClass"
                 && $0.inheritsFromTypes == []
@@ -227,7 +237,7 @@ final class ClassVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds FooFooClass") {
+          it("finds FooClass.FooFooClass") {
             let matching = self.sut.classes.filter {
               $0.name == "FooFooClass"
                 && $0.inheritsFromTypes == []
@@ -237,7 +247,7 @@ final class ClassVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarFooFooClass") {
+          it("finds FooClass.FooFooClass.BarFooFooClass") {
             let matching = self.sut.classes.filter {
               $0.name == "BarFooFooClass"
                 && $0.inheritsFromTypes == []
@@ -247,7 +257,7 @@ final class ClassVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarFooEnum") {
+          it("finds FooClass.BarFooEnum") {
             let matching = self.sut.innerEnums.filter {
               $0.name == "BarFooEnum"
                 && $0.inheritsFromTypes == []
@@ -257,7 +267,7 @@ final class ClassVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarBarFooClass") {
+          it("finds FooClass.BarFooEnum.BarBarFooClass") {
             let matching = self.sut.classes.filter {
               $0.name == "BarBarFooClass"
                 && $0.inheritsFromTypes == []

--- a/Sources/SwiftInspectorVisitors/Tests/EnumVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/EnumVisitorSpec.swift
@@ -184,13 +184,13 @@ final class EnumVisitorSpec: QuickSpec {
             let content = """
               public enum FooEnum {
                 public struct BarFooStruct {
-                  public enum BarBarFooEnum {} // TODO: find this class
+                  public enum BarBarFooEnum {}
                 }
                 public enum BarFooEnum: Equatable {
                   public enum BarBarFooEnum {}
                 }
-                public class FooFooClass { // TODO: find this class
-                  public enum BarFooFooEnum {} // TODO: find this enum
+                public class FooFooClass {
+                  public enum BarFooFooEnum {}
                 }
               }
               """
@@ -232,6 +232,33 @@ final class EnumVisitorSpec: QuickSpec {
               $0.name == "BarBarFooEnum"
                 && $0.inheritsFromTypes == []
                 && $0.parentTypeName == "FooEnum.BarFooEnum"
+            }
+            expect(matching.count) == 1
+          }
+
+          it("finds BarBarFooEnum") {
+            let matching = self.sut.enums.filter {
+              $0.name == "BarBarFooEnum"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooEnum.BarFooStruct"
+            }
+            expect(matching.count) == 1
+          }
+
+          it("finds FooFooClass") {
+            let matching = self.sut.innerClasses.filter {
+              $0.name == "FooFooClass"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooEnum"
+            }
+            expect(matching.count) == 1
+          }
+
+          it("finds BarFooFooEnum") {
+            let matching = self.sut.enums.filter {
+              $0.name == "BarFooFooEnum"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooEnum.FooFooClass"
             }
             expect(matching.count) == 1
           }

--- a/Sources/SwiftInspectorVisitors/Tests/EnumVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/EnumVisitorSpec.swift
@@ -209,7 +209,7 @@ final class EnumVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarFooStruct") {
+          it("finds FooEnum.BarFooStruct") {
             let matching = self.sut.innerStructs.filter {
               $0.name == "BarFooStruct"
                 && $0.inheritsFromTypes == []
@@ -218,7 +218,7 @@ final class EnumVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarFooEnum") {
+          it("finds FooEnum.BarFooEnum") {
             let matching = self.sut.enums.filter {
               $0.name == "BarFooEnum"
                 && $0.inheritsFromTypes == ["Equatable"]
@@ -227,7 +227,7 @@ final class EnumVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarBarFooEnum") {
+          it("finds FooEnum.BarFooEnum.BarBarFooEnum") {
             let matching = self.sut.enums.filter {
               $0.name == "BarBarFooEnum"
                 && $0.inheritsFromTypes == []
@@ -236,7 +236,7 @@ final class EnumVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarBarFooEnum") {
+          it("finds FooEnum.BarFooStruct.BarBarFooEnum") {
             let matching = self.sut.enums.filter {
               $0.name == "BarBarFooEnum"
                 && $0.inheritsFromTypes == []
@@ -245,7 +245,7 @@ final class EnumVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds FooFooClass") {
+          it("finds FooEnum.FooFooClass") {
             let matching = self.sut.innerClasses.filter {
               $0.name == "FooFooClass"
                 && $0.inheritsFromTypes == []
@@ -254,7 +254,7 @@ final class EnumVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarFooFooEnum") {
+          it("finds FooEnum.FooFooClass.BarFooFooEnum") {
             let matching = self.sut.enums.filter {
               $0.name == "BarFooFooEnum"
                 && $0.inheritsFromTypes == []

--- a/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
@@ -95,20 +95,16 @@ final class ExtensionVisitorSpec: QuickSpec {
               public extension Array {
                 struct TestStruct {
                   struct InnerStruct {}
-                  // TODO: find this definition
                   class InnerClass {}
-                  // TODO: find this definition
                   enum InnerEnum {}
                 }
 
-                // TODO: find this definition and inner definitions
                 class TestClass {
                   struct InnerStruct {}
                   class InnerClass {}
                   enum InnerEnum {}
                 }
 
-                // TODO: find this definition and inner definitions
                 enum TestEnum {
                   struct InnerStruct {}
                   class InnerClass {}
@@ -126,18 +122,98 @@ final class ExtensionVisitorSpec: QuickSpec {
             expect(self.sut.extensionInfo?.name) == "Array"
           }
 
-          it("finds TestStruct") {
-            let matchingStructs = self.sut.structs.filter {
+          it("finds Array.TestStruct") {
+            let matchingStructs = self.sut.innerStructs.filter {
               $0.name == "TestStruct"
                 && $0.parentTypeName == "Array"
             }
             expect(matchingStructs.count) == 1
           }
 
-          it("finds TestStruct.InnerStruct") {
-            let matchingStructs = self.sut.structs.filter {
+          it("finds Array.TestStruct.InnerStruct") {
+            let matchingStructs = self.sut.innerStructs.filter {
               $0.name == "InnerStruct"
                 && $0.parentTypeName == "Array.TestStruct"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestStruct.InnerClass") {
+            let matchingStructs = self.sut.innerClasses.filter {
+              $0.name == "InnerClass"
+                && $0.parentTypeName == "Array.TestStruct"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestStruct.InnerEnum") {
+            let matchingStructs = self.sut.innerEnums.filter {
+              $0.name == "InnerEnum"
+                && $0.parentTypeName == "Array.TestStruct"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestClass") {
+            let matchingStructs = self.sut.innerClasses.filter {
+              $0.name == "TestClass"
+                && $0.parentTypeName == "Array"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestClass.InnerStruct") {
+            let matchingStructs = self.sut.innerStructs.filter {
+              $0.name == "InnerStruct"
+                && $0.parentTypeName == "Array.TestClass"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestClass.InnerClass") {
+            let matchingStructs = self.sut.innerClasses.filter {
+              $0.name == "InnerClass"
+                && $0.parentTypeName == "Array.TestClass"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestClass.InnerEnum") {
+            let matchingStructs = self.sut.innerEnums.filter {
+              $0.name == "InnerEnum"
+                && $0.parentTypeName == "Array.TestClass"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestEnum") {
+            let matchingStructs = self.sut.innerEnums.filter {
+              $0.name == "TestEnum"
+                && $0.parentTypeName == "Array"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestEnum.InnerStruct") {
+            let matchingStructs = self.sut.innerStructs.filter {
+              $0.name == "InnerStruct"
+                && $0.parentTypeName == "Array.TestEnum"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestEnum.InnerClass") {
+            let matchingStructs = self.sut.innerClasses.filter {
+              $0.name == "InnerClass"
+                && $0.parentTypeName == "Array.TestEnum"
+            }
+            expect(matchingStructs.count) == 1
+          }
+
+          it("finds Array.TestEnum.InnerEnum") {
+            let matchingStructs = self.sut.innerEnums.filter {
+              $0.name == "InnerEnum"
+                && $0.parentTypeName == "Array.TestEnum"
             }
             expect(matchingStructs.count) == 1
           }

--- a/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
@@ -123,99 +123,99 @@ final class ExtensionVisitorSpec: QuickSpec {
           }
 
           it("finds Array.TestStruct") {
-            let matchingStructs = self.sut.innerStructs.filter {
+            let matching = self.sut.innerStructs.filter {
               $0.name == "TestStruct"
                 && $0.parentTypeName == "Array"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestStruct.InnerStruct") {
-            let matchingStructs = self.sut.innerStructs.filter {
+            let matching = self.sut.innerStructs.filter {
               $0.name == "InnerStruct"
                 && $0.parentTypeName == "Array.TestStruct"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestStruct.InnerClass") {
-            let matchingStructs = self.sut.innerClasses.filter {
+            let matching = self.sut.innerClasses.filter {
               $0.name == "InnerClass"
                 && $0.parentTypeName == "Array.TestStruct"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestStruct.InnerEnum") {
-            let matchingStructs = self.sut.innerEnums.filter {
+            let matching = self.sut.innerEnums.filter {
               $0.name == "InnerEnum"
                 && $0.parentTypeName == "Array.TestStruct"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestClass") {
-            let matchingStructs = self.sut.innerClasses.filter {
+            let matching = self.sut.innerClasses.filter {
               $0.name == "TestClass"
                 && $0.parentTypeName == "Array"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestClass.InnerStruct") {
-            let matchingStructs = self.sut.innerStructs.filter {
+            let matching = self.sut.innerStructs.filter {
               $0.name == "InnerStruct"
                 && $0.parentTypeName == "Array.TestClass"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestClass.InnerClass") {
-            let matchingStructs = self.sut.innerClasses.filter {
+            let matching = self.sut.innerClasses.filter {
               $0.name == "InnerClass"
                 && $0.parentTypeName == "Array.TestClass"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestClass.InnerEnum") {
-            let matchingStructs = self.sut.innerEnums.filter {
+            let matching = self.sut.innerEnums.filter {
               $0.name == "InnerEnum"
                 && $0.parentTypeName == "Array.TestClass"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestEnum") {
-            let matchingStructs = self.sut.innerEnums.filter {
+            let matching = self.sut.innerEnums.filter {
               $0.name == "TestEnum"
                 && $0.parentTypeName == "Array"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestEnum.InnerStruct") {
-            let matchingStructs = self.sut.innerStructs.filter {
+            let matching = self.sut.innerStructs.filter {
               $0.name == "InnerStruct"
                 && $0.parentTypeName == "Array.TestEnum"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestEnum.InnerClass") {
-            let matchingStructs = self.sut.innerClasses.filter {
+            let matching = self.sut.innerClasses.filter {
               $0.name == "InnerClass"
                 && $0.parentTypeName == "Array.TestEnum"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
 
           it("finds Array.TestEnum.InnerEnum") {
-            let matchingStructs = self.sut.innerEnums.filter {
+            let matching = self.sut.innerEnums.filter {
               $0.name == "InnerEnum"
                 && $0.parentTypeName == "Array.TestEnum"
             }
-            expect(matchingStructs.count) == 1
+            expect(matching.count) == 1
           }
         }
       }

--- a/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
@@ -82,138 +82,138 @@ final class FileVisitorSpec: QuickSpec {
         }
 
         it("finds TestStruct") {
-          let matchingStructs = self.sut.fileInfo.structs.filter {
+          let matching = self.sut.fileInfo.structs.filter {
             $0.name == "TestStruct"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestStruct.InnerStruct") {
-          let matchingStructs = self.sut.fileInfo.structs.filter {
+          let matching = self.sut.fileInfo.structs.filter {
             $0.name == "InnerStruct"
               && $0.parentTypeName == "TestStruct"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestStruct.InnerClass") {
-          let matchingStructs = self.sut.fileInfo.classes.filter {
+          let matching = self.sut.fileInfo.classes.filter {
             $0.name == "InnerClass"
               && $0.parentTypeName == "TestStruct"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestStruct.InnerEnum") {
-          let matchingStructs = self.sut.fileInfo.enums.filter {
+          let matching = self.sut.fileInfo.enums.filter {
             $0.name == "InnerEnum"
               && $0.parentTypeName == "TestStruct"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestClass") {
-          let matchingStructs = self.sut.fileInfo.classes.filter {
+          let matching = self.sut.fileInfo.classes.filter {
             $0.name == "TestClass"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestClass.InnerStruct") {
-          let matchingStructs = self.sut.fileInfo.structs.filter {
+          let matching = self.sut.fileInfo.structs.filter {
             $0.name == "InnerStruct"
               && $0.parentTypeName == "TestClass"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestClass.InnerClass") {
-          let matchingStructs = self.sut.fileInfo.classes.filter {
+          let matching = self.sut.fileInfo.classes.filter {
             $0.name == "InnerClass"
               && $0.parentTypeName == "TestClass"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestClass.InnerEnum") {
-          let matchingStructs = self.sut.fileInfo.enums.filter {
+          let matching = self.sut.fileInfo.enums.filter {
             $0.name == "InnerEnum"
               && $0.parentTypeName == "TestClass"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestEnum") {
-          let matchingStructs = self.sut.fileInfo.enums.filter {
+          let matching = self.sut.fileInfo.enums.filter {
             $0.name == "TestEnum"
               && $0.parentTypeName == nil
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestEnum.InnerStruct") {
-          let matchingStructs = self.sut.fileInfo.structs.filter {
+          let matching = self.sut.fileInfo.structs.filter {
             $0.name == "InnerStruct"
               && $0.parentTypeName == "TestEnum"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestEnum.InnerClass") {
-          let matchingStructs = self.sut.fileInfo.classes.filter {
+          let matching = self.sut.fileInfo.classes.filter {
             $0.name == "InnerClass"
               && $0.parentTypeName == "TestEnum"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestEnum.InnerEnum") {
-          let matchingStructs = self.sut.fileInfo.enums.filter {
+          let matching = self.sut.fileInfo.enums.filter {
             $0.name == "InnerEnum"
               && $0.parentTypeName == "TestEnum"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds TestProtocol") {
-          let matchingStructs = self.sut.fileInfo.protocols.filter {
+          let matching = self.sut.fileInfo.protocols.filter {
             $0.name == "TestProtocol"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds Array extension") {
-          let matchingStructs = self.sut.fileInfo.extensions.filter {
+          let matching = self.sut.fileInfo.extensions.filter {
             $0.name == "Array"
               && $0.genericRequirements.first?.leftType == "Element"
               && $0.genericRequirements.first?.rightType == "Int"
               && $0.genericRequirements.first?.relationship == .equals
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds Array.InnerStruct") {
-          let matchingStructs = self.sut.fileInfo.structs.filter {
+          let matching = self.sut.fileInfo.structs.filter {
             $0.name == "InnerStruct"
               && $0.parentTypeName == "Array"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds Array.InnerClass") {
-          let matchingStructs = self.sut.fileInfo.classes.filter {
+          let matching = self.sut.fileInfo.classes.filter {
             $0.name == "InnerClass"
               && $0.parentTypeName == "Array"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
         it("finds Array.InnerEnum") {
-          let matchingStructs = self.sut.fileInfo.enums.filter {
+          let matching = self.sut.fileInfo.enums.filter {
             $0.name == "InnerEnum"
               && $0.parentTypeName == "Array"
           }
-          expect(matchingStructs.count) == 1
+          expect(matching.count) == 1
         }
 
       }

--- a/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
@@ -46,18 +46,15 @@ final class FileVisitorSpec: QuickSpec {
               struct TestStruct {
                 struct InnerStruct {}
                 class InnerClass {}
-                // TODO: find this definition
                 enum InnerEnum {}
               }
 
               class TestClass {
                 struct InnerStruct {}
                 class InnerClass {}
-                // TODO: find this definition
                 enum InnerEnum {}
               }
 
-              // TODO: find this definition and inner definitions
               enum TestEnum {
                 struct InnerStruct {}
                 class InnerClass {}
@@ -66,7 +63,6 @@ final class FileVisitorSpec: QuickSpec {
 
               protocol TestProtocol {}
 
-              // TODO: find this definition and inner definitions.
               // TODO: find and propogate this generic constraint to inner types.
               extension Array where Element == Int {
                 struct InnerStruct {}
@@ -108,6 +104,14 @@ final class FileVisitorSpec: QuickSpec {
           expect(matchingStructs.count) == 1
         }
 
+        it("finds TestStruct.InnerEnum") {
+          let matchingStructs = self.sut.fileInfo.enums.filter {
+            $0.name == "InnerEnum"
+              && $0.parentTypeName == "TestStruct"
+          }
+          expect(matchingStructs.count) == 1
+        }
+
         it("finds TestClass") {
           let matchingStructs = self.sut.fileInfo.classes.filter {
             $0.name == "TestClass"
@@ -131,12 +135,87 @@ final class FileVisitorSpec: QuickSpec {
           expect(matchingStructs.count) == 1
         }
 
+        it("finds TestClass.InnerEnum") {
+          let matchingStructs = self.sut.fileInfo.enums.filter {
+            $0.name == "InnerEnum"
+              && $0.parentTypeName == "TestClass"
+          }
+          expect(matchingStructs.count) == 1
+        }
+
+        it("finds TestEnum") {
+          let matchingStructs = self.sut.fileInfo.enums.filter {
+            $0.name == "TestEnum"
+              && $0.parentTypeName == nil
+          }
+          expect(matchingStructs.count) == 1
+        }
+
+        it("finds TestEnum.InnerStruct") {
+          let matchingStructs = self.sut.fileInfo.structs.filter {
+            $0.name == "InnerStruct"
+              && $0.parentTypeName == "TestEnum"
+          }
+          expect(matchingStructs.count) == 1
+        }
+
+        it("finds TestEnum.InnerClass") {
+          let matchingStructs = self.sut.fileInfo.classes.filter {
+            $0.name == "InnerClass"
+              && $0.parentTypeName == "TestEnum"
+          }
+          expect(matchingStructs.count) == 1
+        }
+
+        it("finds TestEnum.InnerEnum") {
+          let matchingStructs = self.sut.fileInfo.enums.filter {
+            $0.name == "InnerEnum"
+              && $0.parentTypeName == "TestEnum"
+          }
+          expect(matchingStructs.count) == 1
+        }
+
         it("finds TestProtocol") {
           let matchingStructs = self.sut.fileInfo.protocols.filter {
             $0.name == "TestProtocol"
           }
           expect(matchingStructs.count) == 1
         }
+
+        it("finds Array extension") {
+          let matchingStructs = self.sut.fileInfo.extensions.filter {
+            $0.name == "Array"
+              && $0.genericRequirements.first?.leftType == "Element"
+              && $0.genericRequirements.first?.rightType == "Int"
+              && $0.genericRequirements.first?.relationship == .equals
+          }
+          expect(matchingStructs.count) == 1
+        }
+
+        it("finds Array.InnerStruct") {
+          let matchingStructs = self.sut.fileInfo.structs.filter {
+            $0.name == "InnerStruct"
+              && $0.parentTypeName == "Array"
+          }
+          expect(matchingStructs.count) == 1
+        }
+
+        it("finds Array.InnerClass") {
+          let matchingStructs = self.sut.fileInfo.classes.filter {
+            $0.name == "InnerClass"
+              && $0.parentTypeName == "Array"
+          }
+          expect(matchingStructs.count) == 1
+        }
+
+        it("finds Array.InnerEnum") {
+          let matchingStructs = self.sut.fileInfo.enums.filter {
+            $0.name == "InnerEnum"
+              && $0.parentTypeName == "Array"
+          }
+          expect(matchingStructs.count) == 1
+        }
+
       }
     }
   }

--- a/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
@@ -187,14 +187,14 @@ final class StructVisitorSpec: QuickSpec {
         }
 
         context("visiting a struct with nested structs, classes, and enums") {
-          beforeEach { // TODO: enums as well
+          beforeEach {
             let content = """
               public struct FooStruct {
                 public class BarFooClass: Equatable {
                   public struct BarBarFooStruct {}
                 }
                 public enum BarFooEnum {
-                  public struct BarBarFooStruct {} // TODO: find this struct
+                  public struct BarBarFooStruct {}
                 }
                 public struct FooFooStruct {
                   public struct BarFooFooStruct {}
@@ -217,7 +217,7 @@ final class StructVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds FooFooStruct") {
+          it("finds FooStruct.FooFooStruct") {
             let matching = self.sut.structs.filter {
               $0.name == "FooFooStruct"
                 && $0.inheritsFromTypes == []
@@ -227,7 +227,7 @@ final class StructVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarFooFooStruct") {
+          it("finds FooStruct.FooFooStruct.BarFooFooStruct") {
             let matching = self.sut.structs.filter {
               $0.name == "BarFooFooStruct"
                 && $0.inheritsFromTypes == []
@@ -237,7 +237,7 @@ final class StructVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarFooClass") {
+          it("finds FooStruct.BarFooClass") {
             let matching = self.sut.innerClasses.filter {
               $0.name == "BarFooClass"
                 && $0.inheritsFromTypes == ["Equatable"]
@@ -247,11 +247,31 @@ final class StructVisitorSpec: QuickSpec {
             expect(matching.count) == 1
           }
 
-          it("finds BarBarFooStruct") {
+          it("finds FooStruct.BarFooClass.BarBarFooStruct") {
             let matching = self.sut.structs.filter {
               $0.name == "BarBarFooStruct"
                 && $0.inheritsFromTypes == []
                 && $0.parentTypeName == "FooStruct.BarFooClass"
+            }
+
+            expect(matching.count) == 1
+          }
+
+          it("finds FooStruct.BarFooEnum") {
+            let matching = self.sut.innerEnums.filter {
+              $0.name == "BarFooEnum"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooStruct"
+            }
+
+            expect(matching.count) == 1
+          }
+
+          it("finds FooStruct.BarFooEnum.BarBarFooStruct") {
+            let matching = self.sut.structs.filter {
+              $0.name == "BarBarFooStruct"
+                && $0.inheritsFromTypes == []
+                && $0.parentTypeName == "FooStruct.BarFooEnum"
             }
 
             expect(matching.count) == 1


### PR DESCRIPTION
This PR builds on top of all the prior PRs to enable the `FileVisitor` to get information about all types defined within a particular file. Note that `ClassVisitor`, `EnumVisitor`, and `ExtensionVisitor` were all built out in parallel PRs, so this PR pulls all those types together.