### PR TITLE
Handle qualified names when parsing types

### DIFF
--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -41,8 +41,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
       return .skipChildren
     }
 
-    // There is no known case where these identifiers can not be cast to SimpleTypeIdentifierSyntax.
-    let name = node.extendedType.as(SimpleTypeIdentifierSyntax.self)!.name.text
+    let name = node.extendedType.qualifiedName
     let typeInheritanceVisitor = TypeInheritanceVisitor()
     typeInheritanceVisitor.walk(node)
     let genericRequirementsVisitor = GenericRequirementVisitor()

--- a/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
@@ -63,16 +63,14 @@ public struct GenericRequirement: Codable, Equatable {
   }
 
   init(node: SameTypeRequirementSyntax) {
-    // There is no known case where these identifiers can not be cast to SimpleTypeIdentifierSyntax.
-    leftType = node.leftTypeIdentifier.as(SimpleTypeIdentifierSyntax.self)!.name.text
-    rightType = node.rightTypeIdentifier.as(SimpleTypeIdentifierSyntax.self)!.name.text
+    leftType = node.leftTypeIdentifier.qualifiedName
+    rightType = node.rightTypeIdentifier.qualifiedName
     relationship = .equals
   }
 
   init(node: ConformanceRequirementSyntax) {
-    // There is no known case where these identifiers can not be cast to SimpleTypeIdentifierSyntax.
-    leftType = node.leftTypeIdentifier.as(SimpleTypeIdentifierSyntax.self)!.name.text
-    rightType = node.rightTypeIdentifier.as(SimpleTypeIdentifierSyntax.self)!.name.text
+    leftType = node.leftTypeIdentifier.qualifiedName
+    rightType = node.rightTypeIdentifier.qualifiedName
     relationship = .conformsTo
   }
 

--- a/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
@@ -55,6 +55,21 @@ final class ExtensionVisitorSpec: QuickSpec {
           }
         }
 
+        context("of a fully-qualified type") {
+          beforeEach {
+            let content = """
+              public extension Foundation.NSURL {}
+            """
+            try? VisitorExecutor.walkVisitor(self.sut, overContent: content)
+          }
+
+          it("returns the conforming type name") {
+            let extensionInfo = self.sut.extensionInfo
+            expect(extensionInfo?.name) == "Foundation.NSURL"
+            expect(extensionInfo?.inheritsFromTypes) == []
+          }
+        }
+
         context("with a single type conformance") {
           it("finds the type name") {
             let content = """
@@ -68,6 +83,21 @@ final class ExtensionVisitorSpec: QuickSpec {
             let extensionInfo = self.sut.extensionInfo
             expect(extensionInfo?.name) == "Array"
             expect(extensionInfo?.inheritsFromTypes) == ["Foo"]
+          }
+        }
+
+        context("with one fully-qualified conformance") {
+          beforeEach {
+            let content = """
+              public extension Array: Swift.Equatable {}
+            """
+            try? VisitorExecutor.walkVisitor(self.sut, overContent: content)
+          }
+
+          it("returns the conforming type name") {
+            let extensionInfo = self.sut.extensionInfo
+            expect(extensionInfo?.name) == "Array"
+            expect(extensionInfo?.inheritsFromTypes) == ["Swift.Equatable"]
           }
         }
 

--- a/Sources/SwiftInspectorVisitors/Tests/GenericRequirementVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/GenericRequirementVisitorSpec.swift
@@ -71,6 +71,44 @@ final class GenericRequirementVisitorSpec: QuickSpec {
         }
       }
 
+      context("visiting a syntax tree involving a protocol that has a left-side fully qualified generic constraint") {
+        it("finds the generic requirements") {
+          let content = """
+            public protocol SomeGenericProtocol: GenericProtocol where
+              FooModule.LeftType == RightType
+            {}
+            """
+
+          try VisitorExecutor.walkVisitor(
+            self.sut,
+            overContent: content)
+
+          expect(self.sut.genericRequirements.first) == GenericRequirement(
+            leftType: "FooModule.LeftType",
+            rightType: "RightType",
+            relationship: .equals)
+        }
+      }
+
+      context("visiting a syntax tree involving a protocol that has a right-side fully qualified generic constraint") {
+        it("finds the generic requirements") {
+          let content = """
+            public protocol SomeGenericProtocol: GenericProtocol where
+              LeftType == FooModule.RightType
+            {}
+            """
+
+          try VisitorExecutor.walkVisitor(
+            self.sut,
+            overContent: content)
+
+          expect(self.sut.genericRequirements.first) == GenericRequirement(
+            leftType: "LeftType",
+            rightType: "FooModule.RightType",
+            relationship: .equals)
+        }
+      }
+
       context("visiting a syntax tree involving a protocol that has two generic constraints") {
         beforeEach {
           let content = """

--- a/Sources/SwiftInspectorVisitors/Tests/TypeInheritanceVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypeInheritanceVisitorSpec.swift
@@ -52,6 +52,19 @@ final class TypeInheritanceVisitorSpec: QuickSpec {
           }
         }
 
+        context("with one fully-qualified conformance") {
+          beforeEach {
+            let content = """
+            class SomeObject: Swift.Equatable {}
+            """
+            try? VisitorExecutor.walkVisitor(self.sut, overContent: content)
+          }
+
+          it("returns the conforming type name") {
+            expect(self.sut.inheritsFromTypes) == ["Swift.Equatable"]
+          }
+        }
+
         context("with multiple conformances on the same line") {
           beforeEach {
             let content = """

--- a/Sources/SwiftInspectorVisitors/Tests/TypeSyntax+NameExtractorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypeSyntax+NameExtractorSpec.swift
@@ -1,0 +1,111 @@
+// Created by Dan Federman on 2/1/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import Nimble
+import Quick
+import SwiftInspectorTestHelpers
+import SwiftSyntax
+
+@testable import SwiftInspectorVisitors
+
+final class TypeSyntaxNameExtractorSpec: QuickSpec {
+  private var sut = EnumVisitor()
+
+  override func spec() {
+    beforeEach {
+      self.sut = EnumVisitor()
+    }
+
+    describe("qualifiedName") {
+      context("when called on a TypeSyntax node representing a SimpleTypeIdentifierSyntax") {
+        final class SimpleTypeIdentifierSyntaxVisitor: SyntaxVisitor {
+          var simpleTypeIdentifier: String?
+          override func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+            simpleTypeIdentifier = TypeSyntax(node).qualifiedName
+            return .skipChildren
+          }
+        }
+
+        var visitor: SimpleTypeIdentifierSyntaxVisitor!
+        beforeEach {
+          let content = """
+              var int: Int = 1
+              """
+
+          visitor = SimpleTypeIdentifierSyntaxVisitor()
+          try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+        }
+
+        it("Finds the type") {
+          expect(visitor?.simpleTypeIdentifier) == "Int"
+        }
+      }
+
+      context("when called on a TypeSyntax node representing a MemberTypeIdentifierSyntax") {
+        final class MemberTypeIdentifierSyntaxVisitor: SyntaxVisitor {
+          var memberTypeIdentifier: String?
+          override func visit(_ node: MemberTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+            memberTypeIdentifier = TypeSyntax(node).qualifiedName
+            return .skipChildren
+          }
+        }
+
+        var visitor: MemberTypeIdentifierSyntaxVisitor!
+        beforeEach {
+          let content = """
+              var int: Swift.Int = 1
+              """
+
+          visitor = MemberTypeIdentifierSyntaxVisitor()
+          try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+        }
+
+        it("Finds the type") {
+          expect(visitor?.memberTypeIdentifier) == "Swift.Int"
+        }
+      }
+
+      context("when called on a TypeSyntax node representing an Array") {
+        final class ArraySyntaxVisitor: SyntaxVisitor {
+          override func visit(_ node: ArrayTypeSyntax) -> SyntaxVisitorContinueKind {
+            // This line should assert.
+            _ = TypeSyntax(node).qualifiedName
+            fail("This line should never be reached")
+            return .skipChildren
+          }
+        }
+
+        it("asserts") {
+          expect(try VisitorExecutor.walkVisitor(
+                  ArraySyntaxVisitor(),
+                  overContent: """
+                    var intArray: [Int] = [Int]()
+                    """))
+            .to(throwAssertion())
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwiftInspectorVisitors/TypeInheritanceVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/TypeInheritanceVisitor.swift
@@ -30,7 +30,7 @@ public final class TypeInheritanceVisitor: SyntaxVisitor {
   public private(set) var inheritsFromTypes = [String]()
 
   public override func visit(_ node: InheritedTypeSyntax) -> SyntaxVisitorContinueKind {
-    inheritsFromTypes.append(node.typeName.description.trimmingCharacters(in: .whitespacesAndNewlines))
+    inheritsFromTypes.append(node.typeName.qualifiedName)
     // Children don't have any more information about inheritance, so don't visit them.
     return .skipChildren
   }

--- a/Sources/SwiftInspectorVisitors/TypeSyntax+NameExtractor.swift
+++ b/Sources/SwiftInspectorVisitors/TypeSyntax+NameExtractor.swift
@@ -6,6 +6,7 @@ import SwiftSyntax
 extension TypeSyntax {
 
   /// Returns the the qualified name for the type the receiver represents.
+  /// - Warning: Access this property only on a `SimpleTypeIdentifierSyntax` or `MemberTypeIdentifierSyntax`.
   var qualifiedName: String {
     if let typeIdentifier = self.as(SimpleTypeIdentifierSyntax.self) {
       return typeIdentifier.name.text

--- a/Sources/SwiftInspectorVisitors/TypeSyntax+NameExtractor.swift
+++ b/Sources/SwiftInspectorVisitors/TypeSyntax+NameExtractor.swift
@@ -1,0 +1,25 @@
+// Created by dan_federman on 1/30/21.
+// Copyright © 2021 Airbnb Inc. All rights reserved.
+
+import SwiftSyntax
+
+extension TypeSyntax {
+
+  /// Returns the the qualified name for the type the receiver represents.
+  var qualifiedName: String {
+    if let typeIdentifier = self.as(SimpleTypeIdentifierSyntax.self) {
+      return typeIdentifier.name.text
+
+    } else if let typeIdentifier = self.as(MemberTypeIdentifierSyntax.self) {
+      let baseName = typeIdentifier.baseType.qualifiedName
+      return "\(baseName).\(typeIdentifier.name.text)"
+
+    } else {
+      assertionFailure("TypeSyntax of unexpected type. Defaulting to `description`.")
+      // The description is a source-accurate description of this node,
+      // so it is a reasonable fallback.
+      return description.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+  }
+
+}


### PR DESCRIPTION
I realized this morning that we weren't going to properly parse `Foundation.Array` as a type. This PR creates an extension that aids with the extraction of names from a `TypeSyntax` object, and utilizes it in the places where we were previously either inspecting the `description` directly or force-casting to a `SimpleTypeIdentifierSyntax`.