### PR TITLE
Robustify determining if we've finished parsing the top-level type

### DIFF
--- a/Sources/SwiftInspectorVisitors/ClassVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ClassVisitor.swift
@@ -43,10 +43,12 @@ public final class ClassVisitor: SyntaxVisitor {
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
 
-    guard !hasFinishedParsingClass else {
+    guard !classParsingTracker.hasFinishedParsing else {
       assertionFailure("Encountered more than one top-level class. This is a usage error: a single ClassVisitor instance should start walking only over a node of type `ClassDeclSyntax`")
       return .skipChildren
     }
+
+    classParsingTracker.increment()
 
     if let classInfo = classInfo {
       // Base case. We've previously found a class declaration, so this must be an inner class.
@@ -79,12 +81,12 @@ public final class ClassVisitor: SyntaxVisitor {
   }
 
   public override func visitPost(_ node: ClassDeclSyntax) {
-    guard !hasFinishedParsingClass else { return } 
-    hasFinishedParsingClass = node.identifier.text == classInfo?.name
+    guard !classParsingTracker.hasFinishedParsing else { return }
+    classParsingTracker.decrement()
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    if !hasFinishedParsingClass, let classInfo = classInfo {
+    if !classParsingTracker.hasFinishedParsing, let classInfo = classInfo {
       // We've previously found a class declaration, so this must be an inner struct.
       let qualifiedParentTypeName = QualifiedParentNameCreator.createNameGiven(
         currentParentTypeName: parentTypeName,
@@ -104,7 +106,7 @@ public final class ClassVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    if !hasFinishedParsingClass, let classInfo = classInfo {
+    if !classParsingTracker.hasFinishedParsing, let classInfo = classInfo {
       // We've previously found a class declaration, so this must be an inner enum.
       let qualifiedParentTypeName = QualifiedParentNameCreator.createNameGiven(
         currentParentTypeName: parentTypeName,
@@ -138,7 +140,7 @@ public final class ClassVisitor: SyntaxVisitor {
   // MARK: Private
 
   private let parentTypeName: String?
-  private var hasFinishedParsingClass = false
+  private let classParsingTracker = ParsingTracker()
   private var classInfo: ClassInfo?
   private var innerClasses = [ClassInfo]()
 }

--- a/Sources/SwiftInspectorVisitors/ClassVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ClassVisitor.swift
@@ -31,6 +31,10 @@ public final class ClassVisitor: SyntaxVisitor {
     self.parentTypeName = parentTypeName
   }
 
+  deinit {
+    assert(!classParsingTracker.isParsing)
+  }
+
   /// All of the classes found by this visitor.
   public var classes: [ClassInfo] {
     [classInfo].compactMap { $0 } + innerClasses
@@ -140,7 +144,7 @@ public final class ClassVisitor: SyntaxVisitor {
   // MARK: Private
 
   private let parentTypeName: String?
-  private let classParsingTracker = ParsingTracker()
+  private var classParsingTracker = ParsingTracker()
   private var classInfo: ClassInfo?
   private var innerClasses = [ClassInfo]()
 }

--- a/Sources/SwiftInspectorVisitors/EnumVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/EnumVisitor.swift
@@ -31,6 +31,10 @@ public final class EnumVisitor: SyntaxVisitor {
     self.parentTypeName = parentTypeName
   }
 
+  deinit {
+    assert(!enumParsingTracker.isParsing)
+  }
+
   /// All of the classes found by this visitor.
   public var enums: [EnumInfo] {
     [enumInfo].compactMap { $0 } + innerEnums
@@ -142,7 +146,7 @@ public final class EnumVisitor: SyntaxVisitor {
   // MARK: Private
 
   private let parentTypeName: String?
-  private let enumParsingTracker = ParsingTracker()
+  private var enumParsingTracker = ParsingTracker()
   private var enumInfo: EnumInfo?
   private var innerEnums = [EnumInfo]()
 }

--- a/Sources/SwiftInspectorVisitors/ParsingTracker.swift
+++ b/Sources/SwiftInspectorVisitors/ParsingTracker.swift
@@ -24,16 +24,20 @@
 
 import Foundation
 
-final class ParsingTracker {
+struct ParsingTracker {
   var hasFinishedParsing: Bool {
-    hasStartedParsing && parsingCount == 0
+    hasStartedParsing && !isParsing
   }
 
-  func increment() {
+  var isParsing: Bool {
+    parsingCount != 0
+  }
+
+  mutating func increment() {
     parsingCount += 1
   }
 
-  func decrement() {
+  mutating func decrement() {
     parsingCount -= 1
   }
 

--- a/Sources/SwiftInspectorVisitors/ParsingTracker.swift
+++ b/Sources/SwiftInspectorVisitors/ParsingTracker.swift
@@ -1,0 +1,47 @@
+// Created by Dan Federman on 2/2/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+final class ParsingTracker {
+  var hasFinishedParsing: Bool {
+    hasStartedParsing && parsingCount == 0
+  }
+
+  func increment() {
+    parsingCount += 1
+  }
+
+  func decrement() {
+    parsingCount -= 1
+  }
+
+  private var hasStartedParsing = false
+  private var parsingCount = 0 {
+    didSet {
+      hasStartedParsing = true
+    }
+  }
+
+}

--- a/Sources/SwiftInspectorVisitors/StructVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/StructVisitor.swift
@@ -43,10 +43,12 @@ public final class StructVisitor: SyntaxVisitor {
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
 
-    guard !hasFinishedParsingStruct else {
+    guard !structParsingTracker.hasFinishedParsing else {
       assertionFailure("Encountered more than one top-level struct. This is a usage error: a single StructVisitor instance should start walking only over a node of type `StructDeclSyntax`")
       return .skipChildren
     }
+
+    structParsingTracker.increment()
 
     if let structInfo = structInfo {
       // Base case. We've previously found a struct declaration, so this must be an inner struct.
@@ -82,11 +84,11 @@ public final class StructVisitor: SyntaxVisitor {
   }
 
   public override func visitPost(_ node: StructDeclSyntax) {
-    hasFinishedParsingStruct = node.identifier.text == structInfo?.name
+    structParsingTracker.decrement()
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    if !hasFinishedParsingStruct, let structInfo = structInfo {
+    if !structParsingTracker.hasFinishedParsing, let structInfo = structInfo {
       // We've previously found a struct declaration, so this must be an inner class.
       let qualifiedParentTypeName = QualifiedParentNameCreator.createNameGiven(
         currentParentTypeName: parentTypeName,
@@ -106,7 +108,7 @@ public final class StructVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    if !hasFinishedParsingStruct, let structInfo = structInfo {
+    if !structParsingTracker.hasFinishedParsing, let structInfo = structInfo {
       // We've previously found a struct declaration, so this must be an inner enum.
       let qualifiedParentTypeName = QualifiedParentNameCreator.createNameGiven(
         currentParentTypeName: parentTypeName,
@@ -140,7 +142,7 @@ public final class StructVisitor: SyntaxVisitor {
   // MARK: Private
 
   private let parentTypeName: String?
-  private var hasFinishedParsingStruct = false
+  private let structParsingTracker = ParsingTracker()
   private var structInfo: StructInfo?
   private var innerStructs = [StructInfo]()
 }

--- a/Sources/SwiftInspectorVisitors/StructVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/StructVisitor.swift
@@ -31,6 +31,10 @@ public final class StructVisitor: SyntaxVisitor {
     self.parentTypeName = parentTypeName
   }
 
+  deinit {
+    assert(!structParsingTracker.isParsing)
+  }
+
   /// All of the structs found by this visitor.
   public var structs: [StructInfo] {
     [structInfo].compactMap { $0 } + innerStructs
@@ -142,7 +146,7 @@ public final class StructVisitor: SyntaxVisitor {
   // MARK: Private
 
   private let parentTypeName: String?
-  private let structParsingTracker = ParsingTracker()
+  private var structParsingTracker = ParsingTracker()
   private var structInfo: StructInfo?
   private var innerStructs = [StructInfo]()
 }

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -96,6 +96,7 @@ final class ClassVisitorSpec: QuickSpec {
           beforeEach {
             let content = """
               public class FooClass {
+                public class FooClass {}
                 public class BarFooClass: Equatable {
                   public class BarBarFooClass: Hashable {}
                 }
@@ -120,6 +121,16 @@ final class ClassVisitorSpec: QuickSpec {
               $0.name == "FooClass"
                 && $0.inheritsFromTypes == []
                 && $0.parentTypeName == nil
+            }
+
+            expect(matching.count) == 1
+          }
+
+          it("finds FooClass.FooClass") {
+            let matching = self.sut.classes.filter {
+              $0.name == "FooClass"
+                && $0.inheritsFromTypes.map { $0.description } == []
+                && $0.parentTypeName == "FooClass"
             }
 
             expect(matching.count) == 1

--- a/Sources/SwiftInspectorVisitors/Tests/EnumVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/EnumVisitorSpec.swift
@@ -183,6 +183,7 @@ final class EnumVisitorSpec: QuickSpec {
           beforeEach {
             let content = """
               public enum FooEnum {
+                public enum FooEnum {}
                 public struct BarFooStruct {
                   public enum BarBarFooEnum {}
                 }
@@ -205,6 +206,15 @@ final class EnumVisitorSpec: QuickSpec {
               $0.name == "FooEnum"
                 && $0.inheritsFromTypes == []
                 && $0.parentTypeName == nil
+            }
+            expect(matching.count) == 1
+          }
+
+          it("finds FooEnum.FooEnum") {
+            let matching = self.sut.enums.filter {
+              $0.name == "FooEnum"
+                && $0.inheritsFromTypes.map { $0.description } == []
+                && $0.parentTypeName == "FooEnum"
             }
             expect(matching.count) == 1
           }

--- a/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
@@ -190,6 +190,7 @@ final class StructVisitorSpec: QuickSpec {
           beforeEach {
             let content = """
               public struct FooStruct {
+                public struct FooStruct {}
                 public class BarFooClass: Equatable {
                   public struct BarBarFooStruct {}
                 }
@@ -212,6 +213,16 @@ final class StructVisitorSpec: QuickSpec {
               $0.name == "FooStruct"
                 && $0.inheritsFromTypes == []
                 && $0.parentTypeName == nil
+            }
+
+            expect(matching.count) == 1
+          }
+
+          it("finds FooStruct.FooStruct") {
+            let matching = self.sut.structs.filter {
+              $0.name == "FooStruct"
+                && $0.inheritsFromTypes.map { $0.description } == []
+                && $0.parentTypeName == "FooStruct"
             }
 
             expect(matching.count) == 1


### PR DESCRIPTION
When running this code on a complicated codebase I realized that how we'd detected that we'd finished parsing a top-level type needed work. This PR introduces a type `ParserTracker` to help encapsulate the logic we need. I'd recommend reviewing unit test changes before reviewing the code.

Note that I haven't made any changes to `ExtensionVisitor` or `ProtocolVisitor` since those types can not be nested.