### PR TITLE
Properly handle generic arguments

### DIFF
--- a/Sources/SwiftInspectorVisitors/Tests/GenericRequirementVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/GenericRequirementVisitorSpec.swift
@@ -224,6 +224,23 @@ final class GenericRequirementVisitorSpec: QuickSpec {
         }
       }
 
+      context("visiting a syntax tree involving an associatedtype that has one generic constraint with its own generic") {
+        it("finds the generic requirements") {
+          let content = """
+            associatedtype SomeType: SomeProtocol where
+              Element == Array<Int>
+            """
+
+          try VisitorExecutor.walkVisitor(
+            self.sut,
+            overContent: content)
+
+          expect(self.sut.genericRequirements.first?.leftType.asSource) == "Element"
+          expect(self.sut.genericRequirements.first?.rightType.asSource) == "Array<Int>"
+          expect(self.sut.genericRequirements.first?.relationship) == .equals
+        }
+      }
+
       context("visiting a syntax tree involving an associatedtype that has two generic constraints") {
         beforeEach {
           let content = """

--- a/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
@@ -100,7 +100,11 @@ final class TypeDescriptionSpec: QuickSpec {
     }
     """.data(using: .utf8)!
 
-  let compositionTestCase = TypeDescription.composition([.simple(name: "Foo"), .optional(.simple(name: "Bar"))])
+  let compositionTestCase = TypeDescription.composition(
+    [
+      .simple(name: "Foo"),
+      .optional(.simple(name: "Bar")),
+    ])
   let compositionTestCaseData = """
     {
       "caseDescription": "composition",
@@ -122,7 +126,11 @@ final class TypeDescriptionSpec: QuickSpec {
     }
     """.data(using: .utf8)!
 
-  let tupleTestCase = TypeDescription.tuple([.simple(name: "Foo"), .optional(.simple(name: "Bar"))])
+  let tupleTestCase = TypeDescription.tuple(
+    [
+      .simple(name: "Foo"),
+      .optional(.simple(name: "Bar"))
+    ])
   let tupleTestCaseData = """
     {
       "caseDescription": "tuple",

--- a/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
@@ -32,24 +32,45 @@ import SwiftSyntax
 
 final class TypeDescriptionSpec: QuickSpec {
 
-  let simpleTestCase = TypeDescription.simple(name: "Foo")
+  let simpleTestCase = TypeDescription.simple(
+    name: "Foo",
+    generics: [
+      .simple(name: "Bar")
+    ])
   let simpleTestCaseData = """
     {
       "caseDescription": "simple",
       "text": "Foo",
-      "typeDescriptions": []
+      "typeDescriptions": [{
+        "caseDescription": "simple",
+        "text": "Bar",
+        "typeDescriptions": []
+      }]
     }
     """.data(using: .utf8)!
 
-  let nestedTestCase = TypeDescription.nested(name: "Bar", parentType: .simple(name: "Foo"))
+  let nestedTestCase = TypeDescription.nested(
+    name: "Bar",
+    parentType: .simple(
+      name: "Foo",
+      generics: [.simple(name: "Int")]),
+    generics: [.simple(name: "String")])
   let nestedTestCaseData = """
     {
-      "typeDescriptions": [],
+      "typeDescriptions": [{
+        "caseDescription": "simple",
+        "text": "String",
+        "typeDescriptions": []
+      }],
       "caseDescription": "nested",
       "typeDescription": {
         "caseDescription": "simple",
         "text": "Foo",
-        "typeDescriptions": []
+        "typeDescriptions": [{
+          "caseDescription": "simple",
+          "text": "Int",
+          "typeDescriptions": []
+      }]
       },
       "text": "Bar"
     }

--- a/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypeDescriptionSpec.swift
@@ -39,7 +39,7 @@ final class TypeDescriptionSpec: QuickSpec {
 
       context("when decoding a simple type") {
         beforeEach {
-          data = "{\"caseDescription\":\"simple\",\"text\":\"Foo\"}".data(using: .utf8)
+          data = "{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]}".data(using: .utf8)
         }
 
         it("decodes the encoded type description") {
@@ -49,7 +49,7 @@ final class TypeDescriptionSpec: QuickSpec {
 
       context("when decoding a nested type") {
         beforeEach {
-          data = "{\"caseDescription\":\"nested\",\"text\":\"Bar\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"}}".data(using: .utf8)
+          data = "{\"typeDescriptions\":[],\"caseDescription\":\"nested\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]},\"text\":\"Bar\"}".data(using: .utf8)
         }
 
         it("decodes the encoded type description") {
@@ -59,7 +59,7 @@ final class TypeDescriptionSpec: QuickSpec {
 
       context("when decoding an optional type") {
         beforeEach {
-          data = "{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"}}".data(using: .utf8)
+          data = "{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]}}".data(using: .utf8)
         }
 
         it("decodes the encoded type description") {
@@ -69,7 +69,7 @@ final class TypeDescriptionSpec: QuickSpec {
 
       context("when decoding an implicitlyUnwrappedOptional type") {
         beforeEach {
-          data = "{\"caseDescription\":\"implicitlyUnwrappedOptional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"}}".data(using: .utf8)
+          data = "{\"caseDescription\":\"implicitlyUnwrappedOptional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]}}".data(using: .utf8)
         }
 
         it("decodes the encoded type description") {
@@ -77,29 +77,9 @@ final class TypeDescriptionSpec: QuickSpec {
         }
       }
 
-      context("when decoding an array type") {
-        beforeEach {
-          data = "{\"caseDescription\":\"array\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"}}".data(using: .utf8)
-        }
-
-        it("decodes the encoded type description") {
-          expect(try decoder.decode(TypeDescription.self, from: data)) == .array(.simple(name: "Foo"))
-        }
-      }
-
-      context("when decoding a dictionary type") {
-        beforeEach {
-          data = "{\"caseDescription\":\"dictionary\",\"typeDescriptionDictionaryKey\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"},\"typeDescriptionDictionaryValue\":{\"caseDescription\":\"simple\",\"text\":\"Bar\"}}".data(using: .utf8)
-        }
-
-        it("decodes the encoded type description") {
-          expect(try decoder.decode(TypeDescription.self, from: data)) == .dictionary(key: .simple(name: "Foo"), value: .simple(name: "Bar"))
-        }
-      }
-
       context("when decoding a composition type") {
         beforeEach {
-          data = "{\"caseDescription\":\"composition\",\"typeDescriptions\":[{\"caseDescription\":\"simple\",\"text\":\"Foo\"},{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Bar\"}}]}".data(using: .utf8)
+          data = "{\"caseDescription\":\"composition\",\"typeDescriptions\":[{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]},{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Bar\",\"typeDescriptions\":[]}}]}".data(using: .utf8)
         }
 
         it("to decode the encoded composition description") {
@@ -109,7 +89,7 @@ final class TypeDescriptionSpec: QuickSpec {
 
       context("when decoding a tuple type") {
         beforeEach {
-          data = "{\"caseDescription\":\"tuple\",\"typeDescriptions\":[{\"caseDescription\":\"simple\",\"text\":\"Foo\"},{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Bar\"}}]}".data(using: .utf8)
+          data = "{\"caseDescription\":\"tuple\",\"typeDescriptions\":[{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]},{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Bar\",\"typeDescriptions\":[]}}]}".data(using: .utf8)
         }
 
         it("decodes the encoded type description") {
@@ -146,7 +126,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when encoding a simple type") {
         beforeEach {
           sut = .simple(name: "Foo")
-          data = "{\"caseDescription\":\"simple\",\"text\":\"Foo\"}".data(using: .utf8)
+          data = "{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]}".data(using: .utf8)
         }
 
         it("successfully encodes the data") {
@@ -157,7 +137,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when encoding a nested type") {
         beforeEach {
           sut = .nested(name: "Bar", parentType: .simple(name: "Foo"))
-          data = "{\"caseDescription\":\"nested\",\"text\":\"Bar\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"}}".data(using: .utf8)
+          data = "{\"typeDescriptions\":[],\"caseDescription\":\"nested\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]},\"text\":\"Bar\"}".data(using: .utf8)
         }
 
         it("successfully encodes the data") {
@@ -168,7 +148,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when encoding an optional type") {
         beforeEach {
           sut = .optional(.simple(name: "Foo"))
-          data = "{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"}}".data(using: .utf8)
+          data = "{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]}}".data(using: .utf8)
         }
 
         it("successfully encodes the data") {
@@ -179,29 +159,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when encoding an implicitlyUnwrappedOptional type") {
         beforeEach {
           sut = .implicitlyUnwrappedOptional(.simple(name: "Foo"))
-          data = "{\"caseDescription\":\"implicitlyUnwrappedOptional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"}}".data(using: .utf8)
-        }
-
-        it("successfully encodes the data") {
-          expect(try encoder.encode(sut)) == data
-        }
-      }
-
-      context("when encoding an array type") {
-        beforeEach {
-          sut = .array(.simple(name: "Foo"))
-          data = "{\"caseDescription\":\"array\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"}}".data(using: .utf8)
-        }
-
-        it("successfully encodes the data") {
-          expect(try encoder.encode(sut)) == data
-        }
-      }
-
-      context("when encoding a dictionary type") {
-        beforeEach {
-          sut = .dictionary(key: .simple(name: "Foo"), value: .simple(name: "Bar"))
-          data = "{\"caseDescription\":\"dictionary\",\"typeDescriptionDictionaryKey\":{\"caseDescription\":\"simple\",\"text\":\"Foo\"},\"typeDescriptionDictionaryValue\":{\"caseDescription\":\"simple\",\"text\":\"Bar\"}}".data(using: .utf8)
+          data = "{\"caseDescription\":\"implicitlyUnwrappedOptional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]}}".data(using: .utf8)
         }
 
         it("successfully encodes the data") {
@@ -212,7 +170,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when encoding a composition type") {
         beforeEach {
           sut = .composition([.simple(name: "Foo"), .optional(.simple(name: "Bar"))])
-          data = "{\"caseDescription\":\"composition\",\"typeDescriptions\":[{\"caseDescription\":\"simple\",\"text\":\"Foo\"},{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Bar\"}}]}".data(using: .utf8)
+          data = "{\"caseDescription\":\"composition\",\"typeDescriptions\":[{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]},{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Bar\",\"typeDescriptions\":[]}}]}".data(using: .utf8)
         }
 
         it("to decode the encoded composition description") {
@@ -223,7 +181,7 @@ final class TypeDescriptionSpec: QuickSpec {
       context("when encoding a tuple type") {
         beforeEach {
           sut = .tuple([.simple(name: "Foo"), .optional(.simple(name: "Bar"))])
-          data = "{\"caseDescription\":\"tuple\",\"typeDescriptions\":[{\"caseDescription\":\"simple\",\"text\":\"Foo\"},{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Bar\"}}]}".data(using: .utf8)
+          data = "{\"caseDescription\":\"tuple\",\"typeDescriptions\":[{\"caseDescription\":\"simple\",\"text\":\"Foo\",\"typeDescriptions\":[]},{\"caseDescription\":\"optional\",\"typeDescription\":{\"caseDescription\":\"simple\",\"text\":\"Bar\",\"typeDescriptions\":[]}}]}".data(using: .utf8)
         }
 
         it("successfully encodes the data") {
@@ -278,17 +236,64 @@ final class TypeDescriptionSpec: QuickSpec {
         }
 
         var visitor: MemberTypeIdentifierSyntaxVisitor!
-        beforeEach {
-          let content = """
+        context("without a generic argument") {
+          beforeEach {
+            let content = """
               var int: Swift.Int = 1
               """
 
-          visitor = MemberTypeIdentifierSyntaxVisitor()
-          try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+            visitor = MemberTypeIdentifierSyntaxVisitor()
+            try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+          }
+
+          it("Finds the type") {
+            expect(visitor?.nestedTypeIdentifier?.asSource) == "Swift.Int"
+          }
         }
 
-        it("Finds the type") {
-          expect(visitor?.nestedTypeIdentifier?.asSource) == "Swift.Int"
+        context("with a right-hand generic argument") {
+          beforeEach {
+            let content = """
+              var intArray: Swift.Array<Int> = [1]
+              """
+
+            visitor = MemberTypeIdentifierSyntaxVisitor()
+            try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+          }
+
+          it("Finds the type") {
+            expect(visitor?.nestedTypeIdentifier?.asSource) == "Swift.Array<Int>"
+          }
+        }
+
+        context("with a left-hand generic argument") {
+          beforeEach {
+            let content = """
+              var genericType: OuterGenericType<Int>.InnerType
+              """
+
+            visitor = MemberTypeIdentifierSyntaxVisitor()
+            try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+          }
+
+          it("Finds the type") {
+            expect(visitor?.nestedTypeIdentifier?.asSource) == "OuterGenericType<Int>.InnerType"
+          }
+        }
+
+        context("with a generic arguments on both sides") {
+          beforeEach {
+            let content = """
+              var genericType: OuterGenericType<Int>.InnerGenericType<String>
+              """
+
+            visitor = MemberTypeIdentifierSyntaxVisitor()
+            try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+          }
+
+          it("Finds the type") {
+            expect(visitor?.nestedTypeIdentifier?.asSource) == "OuterGenericType<Int>.InnerGenericType<String>"
+          }
         }
       }
 
@@ -392,11 +397,53 @@ final class TypeDescriptionSpec: QuickSpec {
         }
 
         it("Finds the type") {
-          expect(visitor.arrayTypeIdentifier?.asSource) == "[Int]"
+          expect(visitor.arrayTypeIdentifier?.asSource) == "Array<Int>"
         }
       }
 
-      context("when called on a TypeSyntax node representing an DictionaryTypeSyntax") {
+      context("when called on a TypeSyntax node representing an array not of form ArrayTypeSyntax") {
+        final class SimpleTypeIdentifierSyntaxVisitor: SyntaxVisitor {
+          var typeIdentifier: TypeDescription?
+          override func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+            typeIdentifier = TypeSyntax(node).typeDescription
+            return .skipChildren
+          }
+        }
+
+        var visitor: SimpleTypeIdentifierSyntaxVisitor!
+        context("when the array is one-dimensional") {
+          beforeEach {
+            let content = """
+            var intArray: Array<Int>
+            """
+
+            visitor = SimpleTypeIdentifierSyntaxVisitor()
+            try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+          }
+
+          it("Finds the type") {
+            expect(visitor.typeIdentifier?.asSource) == "Array<Int>"
+          }
+        }
+
+        context("when the array is two-dimensional") {
+          beforeEach {
+            let content = """
+            var twoDimensionalIntArray: Array<Array<Int>>
+            """
+
+            visitor = SimpleTypeIdentifierSyntaxVisitor()
+            try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+          }
+
+          it("Finds the type") {
+            expect(visitor.typeIdentifier?.asSource) == "Array<Array<Int>>"
+          }
+        }
+
+      }
+
+      context("when called on a TypeSyntax node representing a DictionaryTypeSyntax") {
         final class DictionaryTypeSyntaxVisitor: SyntaxVisitor {
           var dictionaryTypeIdentifier: TypeDescription?
           override func visit(_ node: DictionaryTypeSyntax) -> SyntaxVisitorContinueKind {
@@ -416,7 +463,48 @@ final class TypeDescriptionSpec: QuickSpec {
         }
 
         it("Finds the type") {
-          expect(visitor.dictionaryTypeIdentifier?.asSource) == "[Int: String]"
+          expect(visitor.dictionaryTypeIdentifier?.asSource) == "Dictionary<Int, String>"
+        }
+      }
+
+      context("when called on a TypeSyntax node representing a dictionary not of form DictionaryTypeSyntax") {
+        final class SimpleTypeIdentifierSyntaxVisitor: SyntaxVisitor {
+          var typeIdentifier: TypeDescription?
+          override func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
+            typeIdentifier = TypeSyntax(node).typeDescription
+            return .skipChildren
+          }
+        }
+
+        var visitor: SimpleTypeIdentifierSyntaxVisitor!
+        context("when the dictionary is one-dimensional") {
+          beforeEach {
+            let content = """
+            var dictionary: Dictionary<Int, String>
+            """
+
+            visitor = SimpleTypeIdentifierSyntaxVisitor()
+            try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+          }
+
+          it("Finds the type") {
+            expect(visitor.typeIdentifier?.asSource) == "Dictionary<Int, String>"
+          }
+        }
+
+        context("when the dictionary is two-dimensional") {
+          beforeEach {
+            let content = """
+            var twoDimensionalDictionary: Dictionary<Int, Dictionary<Int, String>>
+            """
+
+            visitor = SimpleTypeIdentifierSyntaxVisitor()
+            try? VisitorExecutor.walkVisitor(visitor, overContent: content)
+          }
+
+          it("Finds the type") {
+            expect(visitor.typeIdentifier?.asSource) == "Dictionary<Int, Dictionary<Int, String>>"
+          }
         }
       }
 

--- a/Sources/SwiftInspectorVisitors/TypeDescription.swift
+++ b/Sources/SwiftInspectorVisitors/TypeDescription.swift
@@ -78,7 +78,7 @@ public enum TypeDescription: Codable, Equatable {
    * We’ll Get There™
    */
 
-  /// A cononical representation of this type that can be used as source code.
+  /// A canonical representation of this type that can be used as source code.
   public var asSource: String {
     switch self {
     case let .simple(name, generics):

--- a/Sources/SwiftInspectorVisitors/TypeDescription.swift
+++ b/Sources/SwiftInspectorVisitors/TypeDescription.swift
@@ -26,20 +26,16 @@ import SwiftSyntax
 
 /// An enum that describes a parsed type in a cannonical form.
 public enum TypeDescription: Codable, Equatable {
-  /// A root type. e.g. Int
-  case simple(name: String)
-  /// A nested type. e.g. Array.Element
-  indirect case nested(name: String, parentType: TypeDescription)
+  /// A root type with possible generics. e.g. Int, or Array<Int>
+  indirect case simple(name: String, generics: [TypeDescription])
+  /// A nested type with possible generics. e.g. Array.Element or Array<Element>
+  indirect case nested(name: String, parentType: TypeDescription, generics: [TypeDescription])
   /// A composed type. e.g. Identifiable & Equatable
   indirect case composition([TypeDescription])
   /// An optional type. e.g. Int?
   indirect case optional(TypeDescription)
   /// An implicitly unwrapped optional type. eg. Int!
   indirect case implicitlyUnwrappedOptional(TypeDescription)
-  /// An array. e.g. [Int]
-  indirect case array(TypeDescription)
-  /// A dictionary. e.g. [Int: String]
-  indirect case dictionary(key: TypeDescription, value: TypeDescription)
   /// A tuple. e.g. (Int, String)
   indirect case tuple([TypeDescription])
   /// A type that can't be represented by the above cases.
@@ -60,6 +56,16 @@ public enum TypeDescription: Codable, Equatable {
     }
   }
 
+  /// A shortcut for creating a `simple` case without any generic types.
+  public static func simple(name: String) -> TypeDescription {
+    .simple(name: name, generics: [])
+  }
+
+  /// A shortcut for creating a `nested` case without any generic types.
+  public static func nested(name: String, parentType: TypeDescription) -> TypeDescription {
+    .nested(name: name, parentType: parentType, generics: [])
+  }
+
   /*
    * Note that we do not yet support the following syntax types:
    * SomeTypeSyntax
@@ -72,23 +78,27 @@ public enum TypeDescription: Codable, Equatable {
    * We’ll Get There™
    */
 
-  /// A source-code representation of this type that can be used in code generation.
+  /// A cononical representation of this type that can be used as source code.
   public var asSource: String {
     switch self {
-    case let .simple(name):
-      return name
-    case let .array(type):
-      return "[\(type.asSource)]"
+    case let .simple(name, generics):
+      if generics.isEmpty {
+        return name
+      } else {
+        return "\(name)<\(generics.map { $0.asSource }.joined(separator: ", "))>"
+      }
     case let .composition(types):
       return types.map { $0.asSource }.joined(separator: " & ")
     case let .optional(type):
       return "\(type.asSource)?"
     case let .implicitlyUnwrappedOptional(type):
       return "\(type.asSource)!"
-    case let .dictionary(key, value):
-      return "[\(key.asSource): \(value.asSource)]"
-    case let .nested(name, parentType):
-      return "\(parentType.asSource).\(name)"
+    case let .nested(name, parentType, generics):
+      if generics.isEmpty {
+        return "\(parentType.asSource).\(name)"
+      } else {
+        return "\(parentType.asSource).\(name)<\(generics.map { $0.asSource }.joined(separator: ", "))>"
+      }
     case let .tuple(types):
       return "(\(types.map { $0.asSource }.joined(separator: ", ")))"
     case let .unknown(text):
@@ -101,7 +111,8 @@ public enum TypeDescription: Codable, Equatable {
     let caseDescription = try values.decode(String.self, forKey: .caseDescription)
     if caseDescription == Self.simpleDescription {
       let text = try values.decode(String.self, forKey: .text)
-      self = .simple(name: text)
+      let typeDescriptions = try values.decode([Self].self, forKey: .typeDescriptions)
+      self = .simple(name: text, generics: typeDescriptions)
 
     } else if caseDescription == Self.unknownDescription {
       let text = try values.decode(String.self, forKey: .text)
@@ -110,7 +121,8 @@ public enum TypeDescription: Codable, Equatable {
     } else if caseDescription == Self.nestedDescription {
       let text = try values.decode(String.self, forKey: .text)
       let parentType = try values.decode(Self.self, forKey: .typeDescription)
-      self = .nested(name: text, parentType: parentType)
+      let typeDescriptions = try values.decode([Self].self, forKey: .typeDescriptions)
+      self = .nested(name: text, parentType: parentType, generics: typeDescriptions)
 
     } else if caseDescription == Self.optionalDescription {
       let typeDescription = try values.decode(Self.self, forKey: .typeDescription)
@@ -119,15 +131,6 @@ public enum TypeDescription: Codable, Equatable {
     } else if caseDescription == Self.implicitlyUnwrappedOptionalDescription {
       let typeDescription = try values.decode(Self.self, forKey: .typeDescription)
       self = .implicitlyUnwrappedOptional(typeDescription)
-
-    } else if caseDescription == Self.arrayDescription {
-      let typeDescription = try values.decode(Self.self, forKey: .typeDescription)
-      self = .array(typeDescription)
-
-    } else if caseDescription == Self.dictionaryDescription {
-      let key = try values.decode(Self.self, forKey: .typeDescriptionDictionaryKey)
-      let value = try values.decode(Self.self, forKey: .typeDescriptionDictionaryValue)
-      self = .dictionary(key: key, value: value)
 
     } else if caseDescription == Self.compositionDescription {
       let typeDescriptions = try values.decode([Self].self, forKey: .typeDescriptions)
@@ -146,23 +149,21 @@ public enum TypeDescription: Codable, Equatable {
     var container = encoder.container(keyedBy: CodingKeys.self)
     try container.encode(caseDescription, forKey: .caseDescription)
     switch self {
-    case let .simple(name):
+    case let .simple(name, generics):
       try container.encode(name, forKey: .text)
+      try container.encode(generics, forKey: .typeDescriptions)
     case let .unknown(text):
       try container.encode(text, forKey: .text)
     case let .optional(type),
-         let .array(type),
          let .implicitlyUnwrappedOptional(type):
       try container.encode(type, forKey: .typeDescription)
     case let .tuple(types),
          let .composition(types):
       try container.encode(types, forKey: .typeDescriptions)
-    case let .dictionary(key, value):
-      try container.encode(key, forKey: .typeDescriptionDictionaryKey)
-      try container.encode(value, forKey: .typeDescriptionDictionaryValue)
-    case let .nested(name, parentType):
+    case let .nested(name, parentType, generics):
       try container.encode(name, forKey: .text)
       try container.encode(parentType, forKey: .typeDescription)
+      try container.encode(generics, forKey: .typeDescriptions)
     }
   }
 
@@ -175,10 +176,6 @@ public enum TypeDescription: Codable, Equatable {
     case typeDescription
     /// The value for this key is the associated value of type [TypeDescription]
     case typeDescriptions
-    /// The value for this key is the associated value of type TypeDescription that represents the key in a dictionary.
-    case typeDescriptionDictionaryKey
-    /// The value for this key is the associated value of type TypeDescription that represents the value in a dictionary
-    case typeDescriptionDictionaryValue
   }
 
   public enum CodingError: Error {
@@ -187,12 +184,8 @@ public enum TypeDescription: Codable, Equatable {
 
   private var caseDescription: String {
     switch self {
-    case .array:
-      return Self.arrayDescription
     case .composition:
       return Self.compositionDescription
-    case .dictionary:
-      return Self.dictionaryDescription
     case .implicitlyUnwrappedOptional:
       return Self.implicitlyUnwrappedOptionalDescription
     case .nested:
@@ -213,8 +206,6 @@ public enum TypeDescription: Codable, Equatable {
   private static let compositionDescription = "composition"
   private static let optionalDescription = "optional"
   private static let implicitlyUnwrappedOptionalDescription = "implicitlyUnwrappedOptional"
-  private static let arrayDescription = "array"
-  private static let dictionaryDescription = "dictionary"
   private static let tupleDescription = "tuple"
   private static let unknownDescription = "unknown"
 }
@@ -227,12 +218,23 @@ extension TypeSyntax {
   ///            `AttributedTypeSyntax`, or `UnknownTypeSyntax`
   var typeDescription: TypeDescription {
     if let typeIdentifier = self.as(SimpleTypeIdentifierSyntax.self) {
-      return .simple(name: typeIdentifier.name.text)
+      let genericTypeVisitor = GenericArgumentVisitor()
+      if let genericArgumentClause = typeIdentifier.genericArgumentClause {
+        genericTypeVisitor.walk(genericArgumentClause)
+      }
+      return .simple(
+        name: typeIdentifier.name.text,
+        generics: genericTypeVisitor.genericArguments)
 
     } else if let typeIdentifier = self.as(MemberTypeIdentifierSyntax.self) {
+      let genericTypeVisitor = GenericArgumentVisitor()
+      if let genericArgumentClause = typeIdentifier.genericArgumentClause {
+        genericTypeVisitor.walk(genericArgumentClause)
+      }
       return .nested(
         name: typeIdentifier.name.text,
-        parentType: typeIdentifier.baseType.typeDescription)
+        parentType: typeIdentifier.baseType.typeDescription,
+        generics: genericTypeVisitor.genericArguments)
 
     } else if let typeIdentifiers = self.as(CompositionTypeSyntax.self) {
       return .composition(typeIdentifiers.elements.map { $0.type.typeDescription })
@@ -244,12 +246,18 @@ extension TypeSyntax {
       return .implicitlyUnwrappedOptional(typeIdentifier.wrappedType.typeDescription)
 
     } else if let typeIdentifier = self.as(ArrayTypeSyntax.self) {
-      return .array(typeIdentifier.elementType.typeDescription)
+      // An array of the form [Type] is synonymous with Array<Type>.
+      // Utilize a simple type rather than creating another enum case.
+      let elementDescription = typeIdentifier.elementType.typeDescription.asSource
+      return .simple(name: "Array<\(elementDescription)>")
 
     } else if let typeIdentifier = self.as(DictionaryTypeSyntax.self) {
-      return .dictionary(
-        key: typeIdentifier.keyType.typeDescription,
-        value: typeIdentifier.valueType.typeDescription)
+      // An array of the form [KeyType: ValueType] is synonymous with Dictionary<KeyType, ValueType>.
+      // Utilize a simple type rather than creating another enum case.
+      let keyDescription = typeIdentifier.keyType.typeDescription
+      let valueDescription = typeIdentifier.valueType.typeDescription
+      return .simple(
+        name: "Dictionary<\(keyDescription.asSource), \(valueDescription.asSource)>")
 
     } else if let typeIdentifiers = self.as(TupleTypeSyntax.self) {
       return .tuple(typeIdentifiers.elements.map { $0.type.typeDescription })
@@ -265,5 +273,15 @@ extension TypeSyntax {
       // so it is a reasonable fallback.
       return .unknown(text: description)
     }
+  }
+}
+
+private final class GenericArgumentVisitor: SyntaxVisitor {
+
+  private(set) var genericArguments = [TypeDescription]()
+
+  override func visit(_ node: GenericArgumentSyntax) -> SyntaxVisitorContinueKind {
+    genericArguments.append(node.argumentType.typeDescription)
+    return .skipChildren
   }
 }

--- a/Sources/SwiftInspectorVisitors/TypeDescription.swift
+++ b/Sources/SwiftInspectorVisitors/TypeDescription.swift
@@ -109,38 +109,39 @@ public enum TypeDescription: Codable, Equatable {
   public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     let caseDescription = try values.decode(String.self, forKey: .caseDescription)
-    if caseDescription == Self.simpleDescription {
+    switch caseDescription {
+    case Self.simpleDescription:
       let text = try values.decode(String.self, forKey: .text)
       let typeDescriptions = try values.decode([Self].self, forKey: .typeDescriptions)
       self = .simple(name: text, generics: typeDescriptions)
 
-    } else if caseDescription == Self.unknownDescription {
+    case Self.unknownDescription:
       let text = try values.decode(String.self, forKey: .text)
       self = .unknown(text: text)
 
-    } else if caseDescription == Self.nestedDescription {
+    case Self.nestedDescription:
       let text = try values.decode(String.self, forKey: .text)
       let parentType = try values.decode(Self.self, forKey: .typeDescription)
       let typeDescriptions = try values.decode([Self].self, forKey: .typeDescriptions)
       self = .nested(name: text, parentType: parentType, generics: typeDescriptions)
 
-    } else if caseDescription == Self.optionalDescription {
+    case Self.optionalDescription:
       let typeDescription = try values.decode(Self.self, forKey: .typeDescription)
       self = .optional(typeDescription)
 
-    } else if caseDescription == Self.implicitlyUnwrappedOptionalDescription {
+    case Self.implicitlyUnwrappedOptionalDescription:
       let typeDescription = try values.decode(Self.self, forKey: .typeDescription)
       self = .implicitlyUnwrappedOptional(typeDescription)
 
-    } else if caseDescription == Self.compositionDescription {
+    case Self.compositionDescription:
       let typeDescriptions = try values.decode([Self].self, forKey: .typeDescriptions)
       self = .composition(typeDescriptions)
 
-    } else if caseDescription == Self.tupleDescription {
+    case Self.tupleDescription:
       let typeDescriptions = try values.decode([Self].self, forKey: .typeDescriptions)
       self = .tuple(typeDescriptions)
 
-    } else {
+    default:
       throw CodingError.unknownCase
     }
   }


### PR DESCRIPTION
This PR enables us to properly identify types with generics. In this PR I also removed the `TypeDescription` `.array` and `.dictionary` cases, since we can now canonically store these types as a `simple` type description with a generic.

I recommend viewing this PR commit by commit.