### PR TITLE
Better comment

### DIFF
--- a/Sources/SwiftInspectorVisitors/TypeDescription.swift
+++ b/Sources/SwiftInspectorVisitors/TypeDescription.swift
@@ -28,7 +28,7 @@ import SwiftSyntax
 public enum TypeDescription: Codable, Equatable {
   /// A root type with possible generics. e.g. Int, or Array<Int>
   indirect case simple(name: String, generics: [TypeDescription])
-  /// A nested type with possible generics. e.g. Array.Element or Array<Element>
+  /// A nested type with possible generics. e.g. Array.Element or Swift.Array<Element>
   indirect case nested(name: String, parentType: TypeDescription, generics: [TypeDescription])
   /// A composed type. e.g. Identifiable & Equatable
   indirect case composition([TypeDescription])

--- a/Sources/SwiftInspectorVisitors/TypeDescription.swift
+++ b/Sources/SwiftInspectorVisitors/TypeDescription.swift
@@ -24,7 +24,7 @@
 
 import SwiftSyntax
 
-/// An enum that describes a parsed type in a cannonical form.
+/// An enum that describes a parsed type in a canonical form.
 public enum TypeDescription: Codable, Equatable {
   /// A root type with possible generics. e.g. Int, or Array<Int>
   indirect case simple(name: String, generics: [TypeDescription])


### PR DESCRIPTION
Why get it right the first time when you could get it right the second? In any case, I realized one of the doc comments didn't provide a good example. So I fixed it.