### PR TITLE
Get modifier information from types

### DIFF
--- a/Sources/SwiftInspectorVisitors/ClassVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ClassVisitor.swift
@@ -73,10 +73,14 @@ public final class ClassVisitor: SyntaxVisitor {
       let typeInheritanceVisitor = TypeInheritanceVisitor()
       typeInheritanceVisitor.walk(node)
 
+      let declarationModifierVisitor = DeclarationModifierVisitor()
+      declarationModifierVisitor.walk(node.members)
+
       classInfo = ClassInfo(
         name: name,
         inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
-        parentType: parentType)
+        parentType: parentType,
+        modifiers: .init(declarationModifierVisitor.modifiers))
       return .visitChildren
     }
   }
@@ -146,5 +150,6 @@ public struct ClassInfo: Codable, Equatable {
   public let name: String
   public let inheritsFromTypes: [TypeDescription]
   public let parentType: TypeDescription?
+  public let modifiers: Set<String>
   // TODO: also find and expose properties on a class
 }

--- a/Sources/SwiftInspectorVisitors/DeclarationModifierVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/DeclarationModifierVisitor.swift
@@ -1,0 +1,43 @@
+// Created by Dan Federman on 2/9/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+import SwiftSyntax
+
+final class DeclarationModifierVisitor: SyntaxVisitor {
+
+  private(set) var modifiers = [String]()
+
+  override func visit(_ node: DeclModifierSyntax) -> SyntaxVisitorContinueKind {
+    modifiers.append(node.name.text)
+    return .skipChildren
+  }
+
+  override func visit(_ node: MemberDeclBlockSyntax) -> SyntaxVisitorContinueKind {
+    // A member declaration block means we've found the body of the type.
+    // There's nothing in this body that would help us determine declaration modifiers.
+    .skipChildren
+  }
+
+}

--- a/Sources/SwiftInspectorVisitors/EnumVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/EnumVisitor.swift
@@ -76,10 +76,14 @@ public final class EnumVisitor: SyntaxVisitor {
       let typeInheritanceVisitor = TypeInheritanceVisitor()
       typeInheritanceVisitor.walk(node)
 
+      let declarationModifierVisitor = DeclarationModifierVisitor()
+      declarationModifierVisitor.walk(node.members)
+
       enumInfo = EnumInfo(
         name: name,
         inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
-        parentType: parentType)
+        parentType: parentType,
+        modifiers: .init(declarationModifierVisitor.modifiers))
       return .visitChildren
     }
   }
@@ -148,5 +152,6 @@ public struct EnumInfo: Codable, Equatable {
   public let name: String
   public let inheritsFromTypes: [TypeDescription]
   public let parentType: TypeDescription?
+  public let modifiers: Set<String>
   // TODO: also find and expose properties on a class
 }

--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -48,10 +48,14 @@ public final class ExtensionVisitor: SyntaxVisitor {
     let genericRequirementsVisitor = GenericRequirementVisitor()
     genericRequirementsVisitor.walk(node)
 
+    let declarationModifierVisitor = DeclarationModifierVisitor()
+    declarationModifierVisitor.walk(node.members)
+
     extensionInfo = ExtensionInfo(
       typeDescription: node.extendedType.typeDescription,
       inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
-      genericRequirements: genericRequirementsVisitor.genericRequirements)
+      genericRequirements: genericRequirementsVisitor.genericRequirements,
+      modifiers: .init(declarationModifierVisitor.modifiers))
     return .visitChildren
   }
 
@@ -126,5 +130,6 @@ public struct ExtensionInfo: Codable, Equatable {
   public let typeDescription: TypeDescription
   public private(set) var inheritsFromTypes: [TypeDescription]
   public private(set) var genericRequirements: [GenericRequirement]
+  public let modifiers: Set<String>
   // TODO: also find and expose computed properties
 }

--- a/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
@@ -41,10 +41,14 @@ public final class ProtocolVisitor: SyntaxVisitor {
     let genericRequirementsVisitor = GenericRequirementVisitor()
     genericRequirementsVisitor.walk(node)
 
+    let declarationModifierVisitor = DeclarationModifierVisitor()
+    declarationModifierVisitor.walk(node.members)
+
     protocolInfo = ProtocolInfo(
       name: node.identifier.text,
       inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
-      genericRequirements: genericRequirementsVisitor.genericRequirements)
+      genericRequirements: genericRequirementsVisitor.genericRequirements,
+      modifiers: .init(declarationModifierVisitor.modifiers))
 
     // We don't (yet) care about what is in this protocol. When we start looking for
     // properties on this protocol we'll need to start visiting children.
@@ -79,5 +83,6 @@ public struct ProtocolInfo: Codable, Equatable {
   public let name: String
   public let inheritsFromTypes: [TypeDescription]
   public let genericRequirements: [GenericRequirement]
+  public let modifiers: Set<String>
   // TODO: also find and expose properties on a protocol
 }

--- a/Sources/SwiftInspectorVisitors/StructVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/StructVisitor.swift
@@ -77,10 +77,14 @@ public final class StructVisitor: SyntaxVisitor {
       let typeInheritanceVisitor = TypeInheritanceVisitor()
       typeInheritanceVisitor.walk(node)
 
+      let declarationModifierVisitor = DeclarationModifierVisitor()
+      declarationModifierVisitor.walk(node.members)
+
       structInfo = StructInfo(
         name: name,
         inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
-        parentType: parentType)
+        parentType: parentType,
+        modifiers: .init(declarationModifierVisitor.modifiers))
       return .visitChildren
     }
   }
@@ -149,5 +153,6 @@ public struct StructInfo: Codable, Equatable {
   public let name: String
   public let inheritsFromTypes: [TypeDescription]
   public let parentType: TypeDescription?
+  public let modifiers: Set<String>
   // TODO: also find and expose properties on a struct
 }

--- a/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ClassVisitorSpec.swift
@@ -96,7 +96,7 @@ final class ClassVisitorSpec: QuickSpec {
           beforeEach {
             let content = """
               public class FooClass {
-                public class FooClass {}
+                internal class FooClass {}
                 public class BarFooClass: Equatable {
                   public class BarBarFooClass: Hashable {}
                 }
@@ -121,6 +121,7 @@ final class ClassVisitorSpec: QuickSpec {
               $0.name == "FooClass"
                 && $0.inheritsFromTypes.map { $0.asSource } == []
                 && $0.parentType?.asSource == nil
+                && $0.modifiers.contains("public")
             }
 
             expect(matching.count) == 1
@@ -131,6 +132,7 @@ final class ClassVisitorSpec: QuickSpec {
               $0.name == "FooClass"
                 && $0.inheritsFromTypes.map { $0.asSource } == []
                 && $0.parentType?.asSource == "FooClass"
+                && $0.modifiers.contains("internal")
             }
 
             expect(matching.count) == 1

--- a/Sources/SwiftInspectorVisitors/Tests/EnumVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/EnumVisitorSpec.swift
@@ -96,7 +96,7 @@ final class EnumVisitorSpec: QuickSpec {
           beforeEach {
             let content = """
               public enum FooEnum {
-                public enum BarFooEnum: Equatable {
+                internal enum BarFooEnum: Equatable {
                   public enum BarBarFooEnum: Hashable {}
                 }
                 public enum FooFooEnum {
@@ -120,6 +120,7 @@ final class EnumVisitorSpec: QuickSpec {
               $0.name == "FooEnum"
                 && $0.inheritsFromTypes.map { $0.asSource } == []
                 && $0.parentType?.asSource == nil
+                && $0.modifiers.contains("public")
             }
             expect(matching.count) == 1
           }
@@ -129,6 +130,7 @@ final class EnumVisitorSpec: QuickSpec {
               $0.name == "BarFooEnum"
                 && $0.inheritsFromTypes.map { $0.asSource } == ["Equatable"]
                 && $0.parentType?.asSource == "FooEnum"
+                && $0.modifiers.contains("internal")
             }
             expect(matching.count) == 1
           }

--- a/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
@@ -152,6 +152,10 @@ final class ExtensionVisitorSpec: QuickSpec {
             expect(self.sut.extensionInfo?.typeDescription.asSource) == "Array"
           }
 
+          it("finds extension's modifiers") {
+            expect(self.sut.extensionInfo?.modifiers) == .init(["public"])
+          }
+
           it("finds Array.TestStruct") {
             let matching = self.sut.innerStructs.filter {
               $0.name == "TestStruct"

--- a/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
@@ -38,21 +38,31 @@ final class ProtocolVisitorSpec: QuickSpec {
     }
 
     describe("visit(_:)") {
-      context("visiting a single protocol declaration") {
+      context("visiting a single, simple protocol declaration") {
         context("with no conformance") {
-          it("finds the type name") {
+          beforeEach {
             let content = """
               public protocol SomeProtocol {}
               """
 
-            try VisitorExecutor.walkVisitor(
+            try? VisitorExecutor.walkVisitor(
               self.sut,
               overContent: content)
+          }
+          it("finds the type name") {
+            expect(self.sut.protocolInfo?.name) == "SomeProtocol"
+          }
 
-            let protocolInfo = self.sut.protocolInfo
-            expect(protocolInfo?.name) == "SomeProtocol"
-            expect(protocolInfo?.inheritsFromTypes.map { $0.asSource }) == []
-            expect(protocolInfo?.genericRequirements) == []
+          it("finds no inheritance") {
+            expect(self.sut.protocolInfo?.inheritsFromTypes.map { $0.asSource }) == []
+          }
+
+          it("finds no generic requirements") {
+            expect(self.sut.protocolInfo?.genericRequirements) == []
+          }
+
+          it("finds the modifiers") {
+            expect(self.sut.protocolInfo?.modifiers) == .init(["public"])
           }
         }
 

--- a/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/StructVisitorSpec.swift
@@ -96,7 +96,7 @@ final class StructVisitorSpec: QuickSpec {
           beforeEach {
             let content = """
               public struct FooStruct {
-                public struct BarFooStruct: Equatable {
+                internal struct BarFooStruct: Equatable {
                   public struct BarBarFooStruct: Hashable {}
                 }
                 public struct FooFooStruct {
@@ -120,6 +120,7 @@ final class StructVisitorSpec: QuickSpec {
               $0.name == "FooStruct"
                 && $0.inheritsFromTypes.map { $0.asSource } == []
                 && $0.parentType?.asSource == nil
+                && $0.modifiers == .init(["public"])
             }
 
             expect(matching.count) == 1
@@ -130,6 +131,7 @@ final class StructVisitorSpec: QuickSpec {
               $0.name == "BarFooStruct"
                 && $0.inheritsFromTypes.map { $0.asSource } == ["Equatable"]
                 && $0.parentType?.asSource == "FooStruct"
+                && $0.modifiers == .init(["internal"])
             }
 
             expect(matching.count) == 1


### PR DESCRIPTION
This PR creates a `DeclarationModifierVisitor` which can be used for finding declaration modifiers (e.g. "public", "internal", "private", etc).