### PR TITLE
Use correct attribute for exporting an import in tests

### DIFF
--- a/Sources/SwiftInspectorVisitors/Tests/ImportVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ImportVisitorSpec.swift
@@ -83,7 +83,7 @@ final class ImportVisitorSpec: QuickSpec {
       context("with an import statement with an attribute") {
         beforeEach {
           let content = """
-                        @_export import SomeModule
+                        @_exported import SomeModule
 
                         public final protocol Some {}
                         """
@@ -93,7 +93,7 @@ final class ImportVisitorSpec: QuickSpec {
         }
 
         it("returns the appropriate attribute name") {
-          expect(self.sut.imports.first?.attribute) == "_export"
+          expect(self.sut.imports.first?.attribute) == "_exported"
         }
       }
 


### PR DESCRIPTION
We were using `@_export import Foo` when the actual syntax is `@_exported import Foo`.

It doesn't make a difference to the tests, but it's nice when the test code would compile 🙂 