### PR TITLE
Make 'make develop' kill Xcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ bindir ?= $(prefix)/bin
 .PHONY: develop
 develop:
 	swift package generate-xcodeproj --xcconfig-overrides settings.xcconfig
+	(killall -9 Xcode && sleep 0.25) || true # Kills Xcode and waits for the process to terminate if Xcode is open.
 	open SwiftInspector.xcodeproj 
 
 .PHONY: build


### PR DESCRIPTION
If we don't kill Xcode prior to running `make develop` if `SwiftInspector.xcodeproj` is already open, Xcode will complain that it needs to reload the file from disk. On Xcode 12.4, the project reloading will never complete and it will not be possible to run unit tests again until Xcode is killed.

This PR makes killing Xcode part of the `make develop` workflow. Note that we need to wait for a short moment before opening Xcode back up after killing it.