### PR TITLE
Only walk trees in ExtensionVisitor if we know the type we're looking for exists

### DIFF
--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -44,9 +44,14 @@ public final class ExtensionVisitor: SyntaxVisitor {
     }
 
     let typeInheritanceVisitor = TypeInheritanceVisitor()
-    typeInheritanceVisitor.walk(node)
+    if let inheritanceClause = node.inheritanceClause {
+      typeInheritanceVisitor.walk(inheritanceClause)
+    }
+
     let genericRequirementsVisitor = GenericRequirementVisitor()
-    genericRequirementsVisitor.walk(node)
+    if let genericWhereClause = node.genericWhereClause {
+      genericRequirementsVisitor.walk(genericWhereClause)
+    }
 
     let declarationModifierVisitor = DeclarationModifierVisitor()
     if let modifiers = node.modifiers {


### PR DESCRIPTION
This PR helps us visit fewer nodes by only walking nodes if the types we're looking for exist.