### PR TITLE
Create TypealiasVisitor and associated spec

### DIFF
--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -35,6 +35,8 @@ public final class ExtensionVisitor: SyntaxVisitor {
   public private(set) var innerClasses = [ClassInfo]()
   /// Inner enums found by this visitor.
   public private(set) var innerEnums = [EnumInfo]()
+  /// Inner typealiases declarations found by this visitor.
+  public private(set) var innerTypealiases = [TypealiasInfo]()
 
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
 
@@ -80,6 +82,16 @@ public final class ExtensionVisitor: SyntaxVisitor {
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     // We've encountered a protocol declaration, which can only be defined at the top-level. Something is wrong.
     assertionFailure("Encountered a protocol. This is a usage error: a single ExtensionVisitor instance should start walking only over a node of type `ExtensionDeclSyntax`")
+    return .skipChildren
+  }
+
+  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+    let typealiasVisitor = TypealiasVisitor(parentType: extensionInfo?.typeDescription)
+    typealiasVisitor.walk(node)
+
+    innerTypealiases.append(contentsOf: typealiasVisitor.typealiases)
+
+    // We don't need to visit children because our visitor just did that for us.
     return .skipChildren
   }
 

--- a/Sources/SwiftInspectorVisitors/FileVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FileVisitor.swift
@@ -81,6 +81,16 @@ public final class FileVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
+  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+    let typealiasVisitor = TypealiasVisitor()
+    typealiasVisitor.walk(node)
+
+    fileInfo.appendTypealiases(typealiasVisitor.typealiases)
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
   // MARK: Private
 
   private func visitNestableDeclaration<DeclSyntax: NestableDeclSyntax>(node: DeclSyntax) -> SyntaxVisitorContinueKind {
@@ -94,6 +104,7 @@ public final class FileVisitor: SyntaxVisitor {
     // We don't need to visit children because our visitor just did that for us.
     return .skipChildren
   }
+
 }
 
 public struct FileInfo: Codable, Equatable {
@@ -104,6 +115,7 @@ public struct FileInfo: Codable, Equatable {
   public private(set) var classes = [ClassInfo]()
   public private(set) var enums = [EnumInfo]()
   public private(set) var extensions = [ExtensionInfo]()
+  public private(set) var typealiases = [TypealiasInfo]()
 
   mutating func appendImports(_ imports: [ImportStatement]) {
     self.imports += imports
@@ -122,5 +134,8 @@ public struct FileInfo: Codable, Equatable {
   }
   mutating func appendExtension(_ extensionInfo: ExtensionInfo) {
     extensions.append(extensionInfo)
+  }
+  mutating func appendTypealiases(_ typealiases: [TypealiasInfo]) {
+    self.typealiases += typealiases
   }
 }

--- a/Sources/SwiftInspectorVisitors/GenericParameterVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/GenericParameterVisitor.swift
@@ -38,6 +38,6 @@ public final class GenericParameterVisitor: SyntaxVisitor {
 }
 
 public struct GenericParameter: Codable, Equatable {
-  let name: String
-  let inheritsFrom: TypeDescription?
+  public let name: String
+  public let inheritsFrom: TypeDescription?
 }

--- a/Sources/SwiftInspectorVisitors/GenericParameterVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/GenericParameterVisitor.swift
@@ -1,0 +1,43 @@
+// Created by Dan Federman on 2/17/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftSyntax
+
+public final class GenericParameterVisitor: SyntaxVisitor {
+
+  public private(set) var genericParameters = [GenericParameter]()
+
+  public override func visit(_ node: GenericParameterSyntax) -> SyntaxVisitorContinueKind {
+    genericParameters.append(
+      .init(
+        name: node.name.text,
+        inheritsFrom: node.inheritedType?.typeDescription))
+    return .skipChildren
+  }
+}
+
+public struct GenericParameter: Codable, Equatable {
+  let name: String
+  let inheritsFrom: TypeDescription?
+}

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -115,7 +115,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
       // Base case. We've previously found an top-level declaration, so this must be an inner declaration.
       // This visitor shouldn't recurse down into the children.
       // Instead, we'll use a new visitor to get the information from this declaration.
-      let newParentType = TypeDescription(name: topLevelDeclarationName, parent: self.parentType)
+      let newParentType = TypeDescription(name: topLevelDeclarationName, parent: parentType)
       let declarationVisitor = NestableTypeVisitor(parentType: newParentType)
       declarationVisitor.walk(node)
 
@@ -144,8 +144,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
           name: node.identifier.text,
           inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
           parentType: parentType,
-          modifiers: Set(declarationModifierVisitor.modifiers)
-        ))
+          modifiers: Set(declarationModifierVisitor.modifiers)))
 
       return .visitChildren
     }

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -48,6 +48,9 @@ public final class NestableTypeVisitor: SyntaxVisitor {
     [topLevelDeclaration?.nestableInfo].compactMap { $0 } + innerEnums
   }
 
+  /// Typealiases declarations found by this visitor.
+  public private(set) var typealiases = [TypealiasInfo]()
+
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
     visitNestableDeclaration(node: node, topLevelDeclarationCreator: { .topLevelClass($0) })
   }
@@ -81,6 +84,16 @@ public final class NestableTypeVisitor: SyntaxVisitor {
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
     // We've encountered an extension declaration, which can only be defined at the top-level. Something is wrong.
     assertionFailure("Encountered an extension. This is a usage error: a single NestableTypeVisitor instance should start walking only over a nestable declaration syntax node")
+    return .skipChildren
+  }
+
+  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+    let typealiasVisitor = TypealiasVisitor(parentType: parentType)
+    typealiasVisitor.walk(node)
+
+    typealiases.append(contentsOf: typealiasVisitor.typealiases)
+
+    // We don't need to visit children because our visitor just did that for us.
     return .skipChildren
   }
 

--- a/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
@@ -35,6 +35,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
       assertionFailure("Encountered more than one top-level protocol. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
       return .skipChildren
     }
+    let name = node.identifier.text
 
     let typeInheritanceVisitor = TypeInheritanceVisitor()
     typeInheritanceVisitor.walk(node)
@@ -46,11 +47,15 @@ public final class ProtocolVisitor: SyntaxVisitor {
       declarationModifierVisitor.walk(modifiers)
     }
 
+    let typealiasVisitor = TypealiasVisitor(parentType: .simple(name: name))
+    typealiasVisitor.walk(node.members)
+
     protocolInfo = ProtocolInfo(
-      name: node.identifier.text,
+      name: name,
       inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
       genericRequirements: genericRequirementsVisitor.genericRequirements,
-      modifiers: .init(declarationModifierVisitor.modifiers))
+      modifiers: .init(declarationModifierVisitor.modifiers),
+      innerTypealiases: typealiasVisitor.typealiases)
 
     // We don't (yet) care about what is in this protocol. When we start looking for
     // properties on this protocol we'll need to start visiting children.
@@ -86,5 +91,6 @@ public struct ProtocolInfo: Codable, Equatable {
   public let inheritsFromTypes: [TypeDescription]
   public let genericRequirements: [GenericRequirement]
   public let modifiers: Set<String>
+  public let innerTypealiases: [TypealiasInfo]
   // TODO: also find and expose properties on a protocol
 }

--- a/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
@@ -140,6 +140,8 @@ final class ExtensionVisitorSpec: QuickSpec {
                   class InnerClass {}
                   enum InnerEnum {}
                 }
+
+                typealias TestClassTypeAlias = TestClass
               }
               """
 
@@ -248,6 +250,15 @@ final class ExtensionVisitorSpec: QuickSpec {
             let matching = self.sut.innerEnums.filter {
               $0.name == "InnerEnum"
                 && $0.parentType?.asSource == "Array.TestEnum"
+            }
+            expect(matching.count) == 1
+          }
+
+          it("finds Array.TestClassTypeAlias") {
+            let matching = self.sut.innerTypealiases.filter {
+              $0.name == "TestClassTypeAlias"
+                && $0.parentType?.asSource == "Array"
+                && $0.initializer?.asSource == "TestClass"
             }
             expect(matching.count) == 1
           }

--- a/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
@@ -69,6 +69,8 @@ final class FileVisitorSpec: QuickSpec {
                 class InnerClass {}
                 enum InnerEnum {}
               }
+
+              typealias SortableSet<Element: Hashable & Comparable> = Set<Element>
               """
 
           try? VisitorExecutor.walkVisitor(
@@ -216,6 +218,14 @@ final class FileVisitorSpec: QuickSpec {
           expect(matching.count) == 1
         }
 
+        it("finds typealias SortableSet") {
+          let matching = self.sut.fileInfo.typealiases.filter {
+            $0.name == "SortableSet"
+              && $0.genericParameters.first?.name == "Element"
+              && $0.genericParameters.first?.inheritsFrom?.asSource == "Hashable & Comparable"
+          }
+          expect(matching.count) == 1
+        }
       }
     }
   }

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -90,6 +90,26 @@ final class NestableTypeVisitorSpec: QuickSpec {
               expect(classInfo?.parentType).to(beNil())
             }
           }
+
+          context("with a typealias") {
+            beforeEach {
+              let content = """
+                public class SomeClass {
+                  typealias MyString = String
+                }
+                """
+
+              try? VisitorExecutor.walkVisitor(
+                self.sut,
+                overContent: content)
+            }
+
+            it("finds the typealias") {
+              let typealiasInfo = self.sut.typealiases.first
+              expect(typealiasInfo?.name) == "MyString"
+              expect(typealiasInfo?.initializer?.asSource) == "String"
+            }
+          }
         }
 
         context("that is a struct") {
@@ -143,6 +163,26 @@ final class NestableTypeVisitorSpec: QuickSpec {
               expect(structInfo?.parentType).to(beNil())
             }
           }
+
+          context("with a typealias") {
+            beforeEach {
+              let content = """
+                public enum SomeEnum {
+                  typealias MyString = String
+                }
+                """
+
+              try? VisitorExecutor.walkVisitor(
+                self.sut,
+                overContent: content)
+            }
+
+            it("finds the typealias") {
+              let typealiasInfo = self.sut.typealiases.first
+              expect(typealiasInfo?.name) == "MyString"
+              expect(typealiasInfo?.initializer?.asSource) == "String"
+            }
+          }
         }
 
         context("that is an enum") {
@@ -194,6 +234,26 @@ final class NestableTypeVisitorSpec: QuickSpec {
               expect(classInfo?.name) == "SomeEnum"
               expect(classInfo?.inheritsFromTypes.map { $0.asSource }) == ["Foo", "Bar"]
               expect(classInfo?.parentType).to(beNil())
+            }
+          }
+
+          context("with a typealias") {
+            beforeEach {
+              let content = """
+                public enum SomeEnum {
+                  typealias MyString = String
+                }
+                """
+
+              try? VisitorExecutor.walkVisitor(
+                self.sut,
+                overContent: content)
+            }
+
+            it("finds the typealias") {
+              let typealiasInfo = self.sut.typealiases.first
+              expect(typealiasInfo?.name) == "MyString"
+              expect(typealiasInfo?.initializer?.asSource) == "String"
             }
           }
         }

--- a/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
@@ -160,6 +160,24 @@ final class ProtocolVisitorSpec: QuickSpec {
               expect(protocolInfo?.genericRequirements.first?.relationship) == .conformsTo
             }
           }
+
+          context("with a typealias") {
+            it("finds the typealias") {
+              let content = """
+                public protocol SomeProtocol {
+                 typealias Test = Any
+                }
+                """
+
+              try VisitorExecutor.walkVisitor(
+                self.sut,
+                overContent: content)
+
+              let protocolInfo = self.sut.protocolInfo
+              expect(protocolInfo?.innerTypealiases.first?.name) == "Test"
+              expect(protocolInfo?.innerTypealiases.first?.initializer?.asSource) == "Any"
+            }
+          }
         }
 
         context("visiting a code block with multiple top-level declarations") {

--- a/Sources/SwiftInspectorVisitors/Tests/TypealiasVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/TypealiasVisitorSpec.swift
@@ -1,0 +1,85 @@
+// Created by Dan Federman on 2/17/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Nimble
+import Quick
+import SwiftInspectorTestHelpers
+
+@testable import SwiftInspectorVisitors
+
+final class TypealiasVisitorSpec: QuickSpec {
+  private var sut = TypealiasVisitor()
+
+  override func spec() {
+    beforeEach {
+      self.sut = TypealiasVisitor()
+    }
+
+    describe("visit(_:)") {
+      context("visiting a typealias") {
+        var associatedTypeNameToInfoMap: [String: TypealiasInfo]?
+        beforeEach {
+          let content = """
+            public typealias CountableClosedRange<Bound> = ClosedRange<Bound> where Bound : Strideable, Bound.Stride : SignedInteger
+            """
+
+          try? VisitorExecutor.walkVisitor(
+            self.sut,
+            overContent: content)
+
+          associatedTypeNameToInfoMap = self.sut.typealiases
+            .reduce(into: [String: TypealiasInfo]()) { (result, typealiasInfo) in
+              result[typealiasInfo.name] = typealiasInfo
+            }
+        }
+
+        it("finds the typealias CountableClosedRange") {
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]).toNot(beNil())
+        }
+
+        it("finds the typealias CountableClosedRange's generic parameters") {
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.genericParameters.count) == 1
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.genericParameters.first?.name) == "Bound"
+        }
+
+        it("finds the typealias CountableClosedRange's generic requirements") {
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.genericRequirements.count) == 2
+
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.genericRequirements.first?.leftType.asSource) == "Bound"
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.genericRequirements.first?.relationship) == .conformsTo
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.genericRequirements.first?.rightType.asSource) == "Strideable"
+
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.genericRequirements.last?.leftType.asSource) == "Bound.Stride"
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.genericRequirements.last?.relationship) == .conformsTo
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.genericRequirements.last?.rightType.asSource) == "SignedInteger"
+        }
+
+        it("finds the typealias CountableClosedRange's modifiers") {
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.modifiers.count) == 1
+          expect(associatedTypeNameToInfoMap?["CountableClosedRange"]?.modifiers.contains("public")).to(beTrue())
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
@@ -1,0 +1,77 @@
+// Created by Dan Federman on 2/17/21.
+//
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import SwiftSyntax
+
+public final class TypealiasVisitor: SyntaxVisitor {
+
+  public init(parentType: TypeDescription? = nil) {
+    self.parentType = parentType
+  }
+
+  public private(set) var typealiases = [TypealiasInfo]()
+
+  public override func visit(_ node: TypealiasDeclSyntax) -> SyntaxVisitorContinueKind {
+    let name = node.identifier.text
+
+    let genericTypeVisitor = GenericParameterVisitor()
+    if let genericParameterClause = node.genericParameterClause {
+      genericTypeVisitor.walk(genericParameterClause)
+    }
+
+    let genericRequirementsVisitor = GenericRequirementVisitor()
+    if let genericWhereClause = node.genericWhereClause {
+      genericRequirementsVisitor.walk(genericWhereClause)
+    }
+
+    let declarationModifierVisitor = DeclarationModifierVisitor()
+    if let modifiers = node.modifiers {
+      declarationModifierVisitor.walk(modifiers)
+    }
+
+    typealiases.append(
+      .init(
+        name: name,
+        genericParameters: genericTypeVisitor.genericParameters,
+        initializer: node.initializer?.value.typeDescription,
+        genericRequirements: genericRequirementsVisitor.genericRequirements,
+        modifiers: .init(declarationModifierVisitor.modifiers),
+        parentType: parentType))
+
+    return .skipChildren
+  }
+
+  // MARK: Private
+
+  private let parentType: TypeDescription?
+}
+
+public struct TypealiasInfo: Codable, Equatable {
+  public let name: String
+  public let genericParameters: [GenericParameter]
+  public let initializer: TypeDescription?
+  public let genericRequirements: [GenericRequirement]
+  public let modifiers: Set<String>
+  public let parentType: TypeDescription?
+}


### PR DESCRIPTION
Also integrates `typealias`-finding into `ProtocolVisitor`, `ExtensionVisitor`, `NestableTypeVisitor`, and `FileVisitor`.