### PR TITLE
Make types Hashable

### DIFF
--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -122,7 +122,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
   private var hasFinishedParsingExtension = false
 }
 
-public struct ExtensionInfo: Codable, Equatable {
+public struct ExtensionInfo: Codable, Hashable {
   public let typeDescription: TypeDescription
   public private(set) var inheritsFromTypes: [TypeDescription]
   public private(set) var genericRequirements: [GenericRequirement]

--- a/Sources/SwiftInspectorVisitors/FileVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FileVisitor.swift
@@ -107,7 +107,7 @@ public final class FileVisitor: SyntaxVisitor {
 
 }
 
-public struct FileInfo: Codable, Equatable {
+public struct FileInfo: Codable, Hashable {
   public let url: URL
   public private(set) var imports = [ImportStatement]()
   public private(set) var protocols = [ProtocolInfo]()

--- a/Sources/SwiftInspectorVisitors/GenericParameterVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/GenericParameterVisitor.swift
@@ -37,7 +37,7 @@ public final class GenericParameterVisitor: SyntaxVisitor {
   }
 }
 
-public struct GenericParameter: Codable, Equatable {
+public struct GenericParameter: Codable, Hashable {
   public let name: String
   public let inheritsFrom: TypeDescription?
 }

--- a/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/GenericRequirementVisitor.swift
@@ -48,7 +48,7 @@ public final class GenericRequirementVisitor: SyntaxVisitor {
   }
 }
 
-public struct GenericRequirement: Codable, Equatable {
+public struct GenericRequirement: Codable, Hashable {
 
   // MARK: Lifecycle
 

--- a/Sources/SwiftInspectorVisitors/NestableTypeInfo.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeInfo.swift
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-public struct NestableTypeInfo: Codable, Equatable {
+public struct NestableTypeInfo: Codable, Hashable {
   public let name: String
   public let inheritsFromTypes: [TypeDescription]
   public let parentType: TypeDescription?

--- a/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
@@ -86,7 +86,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
   private var hasFinishedParsingProtocol = false
 }
 
-public struct ProtocolInfo: Codable, Equatable {
+public struct ProtocolInfo: Codable, Hashable {
   public let name: String
   public let inheritsFromTypes: [TypeDescription]
   public let genericRequirements: [GenericRequirement]

--- a/Sources/SwiftInspectorVisitors/TypeDescription.swift
+++ b/Sources/SwiftInspectorVisitors/TypeDescription.swift
@@ -25,7 +25,7 @@
 import SwiftSyntax
 
 /// An enum that describes a parsed type in a canonical form.
-public enum TypeDescription: Codable, Equatable {
+public enum TypeDescription: Codable, Hashable {
   /// A root type with possible generics. e.g. Int, or Array<Int>
   indirect case simple(name: String, generics: [TypeDescription])
   /// A nested type with possible generics. e.g. Array.Element or Swift.Array<Element>

--- a/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
@@ -67,7 +67,7 @@ public final class TypealiasVisitor: SyntaxVisitor {
   private let parentType: TypeDescription?
 }
 
-public struct TypealiasInfo: Codable, Equatable {
+public struct TypealiasInfo: Codable, Hashable {
   public let name: String
   public let genericParameters: [GenericParameter]
   public let initializer: TypeDescription?


### PR DESCRIPTION
No reason not to do so that I see, and it enables consumers to store this information in `Set`s, which is helpful.