### PR TITLE
Do not miscategorize nested type

### DIFF
--- a/Sources/SwiftInspectorVisitors/AssociatedtypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/AssociatedtypeVisitor.swift
@@ -52,7 +52,7 @@ public final class AssociatedtypeVisitor: SyntaxVisitor {
   }
 }
 
-public struct AssociatedtypeInfo: Codable, Equatable {
+public struct AssociatedtypeInfo: Codable, Hashable {
   public let name: String
   public let inheritsFromTypes: [TypeDescription]
   public let initializer: TypeDescription?

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -37,15 +37,15 @@ public final class NestableTypeVisitor: SyntaxVisitor {
 
   /// All the classes found by this visitor
   public var classes: [ClassInfo] {
-    [topLevelDeclaration?.nestableInfo].compactMap { $0 } + innerClasses
+    [topLevelDeclaration?.nestableClassInfo].compactMap { $0 } + innerClasses
   }
   /// All the structs found by this visitor
   public var structs: [StructInfo] {
-    [topLevelDeclaration?.nestableInfo].compactMap { $0 } + innerStructs
+    [topLevelDeclaration?.nestableStructInfo].compactMap { $0 } + innerStructs
   }
   /// All of the enums found by this visitor.
   public var enums: [EnumInfo] {
-    [topLevelDeclaration?.nestableInfo].compactMap { $0 } + innerEnums
+    [topLevelDeclaration?.nestableEnumInfo].compactMap { $0 } + innerEnums
   }
 
   /// Typealiases declarations found by this visitor.
@@ -174,6 +174,36 @@ private enum TopLevelDeclaration {
          let .topLevelEnum(topLevelObject),
          let .topLevelStruct(topLevelObject):
       return topLevelObject
+    }
+  }
+
+  var nestableClassInfo: ClassInfo? {
+    switch self {
+    case let .topLevelClass(topLevelObject):
+      return topLevelObject
+    case .topLevelStruct,
+         .topLevelEnum:
+      return nil
+    }
+  }
+
+  var nestableStructInfo: StructInfo? {
+    switch self {
+    case let .topLevelStruct(topLevelObject):
+      return topLevelObject
+    case .topLevelClass,
+         .topLevelEnum:
+      return nil
+    }
+  }
+
+  var nestableEnumInfo: EnumInfo? {
+    switch self {
+    case let .topLevelEnum(topLevelObject):
+      return topLevelObject
+    case .topLevelClass,
+         .topLevelStruct:
+      return nil
     }
   }
 }

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -41,19 +41,29 @@ final class NestableTypeVisitorSpec: QuickSpec {
       context("visiting a single top-level declaration") {
         context("that is a class") {
           context("with no conformance") {
-            it("finds the type name") {
+            beforeEach {
               let content = """
                 public class SomeClass {}
                 """
 
-              try VisitorExecutor.walkVisitor(
+              try? VisitorExecutor.walkVisitor(
                 self.sut,
                 overContent: content)
+            }
 
+            it("finds the type name") {
               let classInfo = self.sut.classes.first
               expect(classInfo?.name) == "SomeClass"
               expect(classInfo?.inheritsFromTypes.map { $0.asSource }) == []
               expect(classInfo?.parentType).to(beNil())
+            }
+
+            it("does not find a struct") {
+              expect(self.sut.structs.count) == 0
+            }
+
+            it("does not find an enum") {
+              expect(self.sut.enums.count) == 0
             }
           }
 
@@ -114,19 +124,29 @@ final class NestableTypeVisitorSpec: QuickSpec {
 
         context("that is a struct") {
           context("with no conformance") {
-            it("finds the type name") {
+            beforeEach {
               let content = """
                 public struct SomeStruct {}
                 """
 
-              try VisitorExecutor.walkVisitor(
+              try? VisitorExecutor.walkVisitor(
                 self.sut,
                 overContent: content)
+            }
 
+            it("finds the type name") {
               let structInfo = self.sut.structs.first
               expect(structInfo?.name) == "SomeStruct"
               expect(structInfo?.inheritsFromTypes.map { $0.asSource }) == []
               expect(structInfo?.parentType).to(beNil())
+            }
+
+            it("does not find a class") {
+              expect(self.sut.classes.count) == 0
+            }
+
+            it("does not find an enum") {
+              expect(self.sut.enums.count) == 0
             }
           }
 
@@ -187,19 +207,29 @@ final class NestableTypeVisitorSpec: QuickSpec {
 
         context("that is an enum") {
           context("with no conformance") {
-            it("finds the type name") {
+            beforeEach {
               let content = """
               public enum SomeEnum {}
               """
 
-              try VisitorExecutor.walkVisitor(
+              try? VisitorExecutor.walkVisitor(
                 self.sut,
                 overContent: content)
+            }
 
+            it("finds the type name") {
               let classInfo = self.sut.enums.first
               expect(classInfo?.name) == "SomeEnum"
               expect(classInfo?.inheritsFromTypes.map { $0.asSource }) == []
               expect(classInfo?.parentType).to(beNil())
+            }
+
+            it("does not find a class") {
+              expect(self.sut.classes.count) == 0
+            }
+
+            it("does not find a struct") {
+              expect(self.sut.structs.count) == 0
             }
           }
 


### PR DESCRIPTION
In the last commit (b5bdd1aaa8ddc54387e5cac5f2fff26a961f79c6) of https://github.com/fdiaz/SwiftInspector/pull/78, I introduced a bug. Previously the compiler was enforcing that I did this right – afterwords with the typealias we had to be a bit more careful. This PR fixes that bug, and also introduces more tests to ensure this doesn't happen again.