### PR TITLE
Create portable binary of SwiftInspector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 prefix ?= /usr/local
 bindir ?= $(prefix)/bin
+xcode_path ?= $(shell xcode-select -p)
+xcode_toolchain ?= $(xcode_path)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx
 
 .PHONY: develop
 develop:
@@ -22,3 +24,14 @@ uninstall:
 .PHONY: clean
 clean:
 	rm -rf .build
+
+# Following https://www.smileykeith.com/2021/03/03/editing-rpaths/
+.PHONY: release
+release: build
+	mkdir -p bin lib
+	cp .build/release/swiftinspector bin
+	cp "$(xcode_toolchain)/lib_InternalSwiftSyntaxParser.dylib" "lib"
+	install_name_tool -delete_rpath @loader_path -delete_rpath $(xcode_toolchain) bin/swiftinspector
+	install_name_tool -add_rpath @executable_path/../lib bin/swiftinspector
+	zip swiftinspector.zip -r bin lib
+	rm -r bin lib

--- a/docs/Releasing.md
+++ b/docs/Releasing.md
@@ -1,0 +1,8 @@
+# Releasing a new version of SwiftInspector
+
+1. Run `make release` from the root of the repo. This will generate a `swiftinspector.zip` file.
+1. Create a new [draft release](https://github.com/fdiaz/SwiftInspector/releases/new) following [semantic versioning](https://semver.org/) for both the tag version and the release title.
+1. In the description of the release point out all the PRs that have been merged since the previous version and describe the new features. 
+1. Attach `swiftinspector.zip` to the release
+1. Select the `This is a pre-release` checkbox
+1. Click on `Publish release`


### PR DESCRIPTION
Thanks to @keith for writing [this](https://www.smileykeith.com/2021/03/03/editing-rpaths/) amazing blog post that helped create this portable binary using SwiftSyntax.

I also added documentation on how to release a new version using this.