### PR TITLE
Enable nestable type visitor to find generic requirements

### DIFF
--- a/Sources/SwiftInspectorVisitors/AssociatedtypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/AssociatedtypeVisitor.swift
@@ -36,9 +36,9 @@ public final class AssociatedtypeVisitor: SyntaxVisitor {
       typeInheritanceVisitor.walk(inheritanceClause)
     }
 
-    let genericRequirementsVisitor = GenericRequirementVisitor()
+    let genericRequirementVisitor = GenericRequirementVisitor()
     if let genericWhereClause = node.genericWhereClause {
-      genericRequirementsVisitor.walk(genericWhereClause)
+      genericRequirementVisitor.walk(genericWhereClause)
     }
 
     associatedTypes.append(
@@ -46,7 +46,7 @@ public final class AssociatedtypeVisitor: SyntaxVisitor {
         name: name,
         inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
         initializer: node.initializer?.value.typeDescription,
-        genericRequirements: genericRequirementsVisitor.genericRequirements))
+        genericRequirements: genericRequirementVisitor.genericRequirements))
 
     return .skipChildren
   }

--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -50,9 +50,9 @@ public final class ExtensionVisitor: SyntaxVisitor {
       typeInheritanceVisitor.walk(inheritanceClause)
     }
 
-    let genericRequirementsVisitor = GenericRequirementVisitor()
+    let genericRequirementVisitor = GenericRequirementVisitor()
     if let genericWhereClause = node.genericWhereClause {
-      genericRequirementsVisitor.walk(genericWhereClause)
+      genericRequirementVisitor.walk(genericWhereClause)
     }
 
     let declarationModifierVisitor = DeclarationModifierVisitor()
@@ -63,7 +63,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
     extensionInfo = ExtensionInfo(
       typeDescription: node.extendedType.typeDescription,
       inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
-      genericRequirements: genericRequirementsVisitor.genericRequirements,
+      genericRequirements: genericRequirementVisitor.genericRequirements,
       modifiers: .init(declarationModifierVisitor.modifiers))
     return .visitChildren
   }

--- a/Sources/SwiftInspectorVisitors/NestableDeclSyntax.swift
+++ b/Sources/SwiftInspectorVisitors/NestableDeclSyntax.swift
@@ -29,6 +29,7 @@ protocol NestableDeclSyntax: SyntaxProtocol {
   var identifier: TokenSyntax { get }
   var inheritanceClause: TypeInheritanceClauseSyntax? { get }
   var genericParameterClause: GenericParameterClauseSyntax? { get }
+  var genericWhereClause: GenericWhereClauseSyntax? { get }
 }
 
 extension ClassDeclSyntax: NestableDeclSyntax {}

--- a/Sources/SwiftInspectorVisitors/NestableTypeInfo.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeInfo.swift
@@ -28,6 +28,7 @@ public struct NestableTypeInfo: Codable, Hashable {
   public let parentType: TypeDescription?
   public let modifiers: Set<String>
   public let genericParameters: [GenericParameter]
+  public let genericRequirements: [GenericRequirement]
   // TODO: also find and expose properties on this type
 }
 

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -154,13 +154,19 @@ public final class NestableTypeVisitor: SyntaxVisitor {
         genericParameterVisitor.walk(genericParameterClause)
       }
 
+      let genericRequirementVisitor = GenericRequirementVisitor()
+      if let genericWhereClause = node.genericWhereClause {
+        genericRequirementVisitor.walk(genericWhereClause)
+      }
+
       topLevelDeclaration = topLevelDeclarationCreator(
         .init(
           name: node.identifier.text,
           inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
           parentType: parentType,
           modifiers: Set(declarationModifierVisitor.modifiers),
-          genericParameters: genericParameterVisitor.genericParameters))
+          genericParameters: genericParameterVisitor.genericParameters,
+          genericRequirements: genericRequirementVisitor.genericRequirements))
 
       return .visitChildren
     }

--- a/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
@@ -43,9 +43,9 @@ public final class ProtocolVisitor: SyntaxVisitor {
     if let inheritanceClause = node.inheritanceClause {
       typeInheritanceVisitor.walk(inheritanceClause)
     }
-    let genericRequirementsVisitor = GenericRequirementVisitor()
+    let genericRequirementVisitor = GenericRequirementVisitor()
     if let genericWhereClause = node.genericWhereClause {
-      genericRequirementsVisitor.walk(genericWhereClause)
+      genericRequirementVisitor.walk(genericWhereClause)
     }
 
     let declarationModifierVisitor = DeclarationModifierVisitor()
@@ -60,7 +60,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
       name: name,
       associatedTypes: associatedtypeVisitor.associatedTypes,
       inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
-      genericRequirements: genericRequirementsVisitor.genericRequirements,
+      genericRequirements: genericRequirementVisitor.genericRequirements,
       modifiers: .init(declarationModifierVisitor.modifiers),
       innerTypealiases: typealiasVisitor.typealiases)
 

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -201,7 +201,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
               expect(structInfo?.genericParameters.map { $0.name }) == ["A", "B"]
             }
 
-            context("that is constrained with a where clause") {
+            context("where one parameter is constrained by a where clause") {
               it("finds the constraint") {
                 let content = """
                 public struct SomeStruct<A, B>: SomeProtocol where A: CustomStringConvertible {
@@ -320,7 +320,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
               expect(enumsInfo?.genericParameters.map { $0.name }) == ["A", "B", "C"]
             }
 
-            context("that is constrained with a where clause") {
+            context("where one parameter is constrained by a where clause") {
               it("finds the constraint") {
                 let content = """
                 public enum SomeEnum<A, B, C>: SomeProtocol where A: CustomStringConvertible {

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -67,7 +67,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             }
           }
 
-          context("with a single generic") {
+          context("with a single generic parameter") {
             it("finds the generic name") {
               let content = """
                 public class SomeClass<T> {}
@@ -80,6 +80,26 @@ final class NestableTypeVisitorSpec: QuickSpec {
               let classInfo = self.sut.classes.first
               expect(classInfo?.name) == "SomeClass"
               expect(classInfo?.genericParameters.map { $0.name }) == ["T"]
+            }
+
+            context("that is constrained with a where clause") {
+              it("finds the constraint") {
+                let content = """
+                public class SomeClass<T>: SomeProtocol where T: CustomStringConvertible {
+                  public typealias SomeProtocolAssociatedType = A
+                }
+                """
+
+                try VisitorExecutor.walkVisitor(
+                  self.sut,
+                  overContent: content)
+
+                let classInfo = self.sut.classes.first
+                expect(classInfo?.name) == "SomeClass"
+                expect(classInfo?.genericRequirements.first?.leftType.asSource) == "T"
+                expect(classInfo?.genericRequirements.first?.rightType.asSource) == "CustomStringConvertible"
+                expect(classInfo?.genericRequirements.first?.relationship) == .conformsTo
+              }
             }
           }
 
@@ -180,6 +200,26 @@ final class NestableTypeVisitorSpec: QuickSpec {
               expect(structInfo?.name) == "SomeStruct"
               expect(structInfo?.genericParameters.map { $0.name }) == ["A", "B"]
             }
+
+            context("that is constrained with a where clause") {
+              it("finds the constraint") {
+                let content = """
+                public struct SomeStruct<A, B>: SomeProtocol where A: CustomStringConvertible {
+                  public typealias SomeProtocolAssociatedType = A
+                }
+                """
+
+                try VisitorExecutor.walkVisitor(
+                  self.sut,
+                  overContent: content)
+
+                let structInfo = self.sut.structs.first
+                expect(structInfo?.name) == "SomeStruct"
+                expect(structInfo?.genericRequirements.first?.leftType.asSource) == "A"
+                expect(structInfo?.genericRequirements.first?.rightType.asSource) == "CustomStringConvertible"
+                expect(structInfo?.genericRequirements.first?.relationship) == .conformsTo
+              }
+            }
           }
 
           context("with a single type conformance") {
@@ -278,6 +318,26 @@ final class NestableTypeVisitorSpec: QuickSpec {
               let enumsInfo = self.sut.enums.first
               expect(enumsInfo?.name) == "SomeEnum"
               expect(enumsInfo?.genericParameters.map { $0.name }) == ["A", "B", "C"]
+            }
+
+            context("that is constrained with a where clause") {
+              it("finds the constraint") {
+                let content = """
+                public enum SomeEnum<A, B, C>: SomeProtocol where A: CustomStringConvertible {
+                  public typealias SomeProtocolAssociatedType = A
+                }
+                """
+
+                try VisitorExecutor.walkVisitor(
+                  self.sut,
+                  overContent: content)
+
+                let enumInfo = self.sut.enums.first
+                expect(enumInfo?.name) == "SomeEnum"
+                expect(enumInfo?.genericRequirements.first?.leftType.asSource) == "A"
+                expect(enumInfo?.genericRequirements.first?.rightType.asSource) == "CustomStringConvertible"
+                expect(enumInfo?.genericRequirements.first?.relationship) == .conformsTo
+              }
             }
           }
 

--- a/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/TypealiasVisitor.swift
@@ -40,9 +40,9 @@ public final class TypealiasVisitor: SyntaxVisitor {
       genericTypeVisitor.walk(genericParameterClause)
     }
 
-    let genericRequirementsVisitor = GenericRequirementVisitor()
+    let genericRequirementVisitor = GenericRequirementVisitor()
     if let genericWhereClause = node.genericWhereClause {
-      genericRequirementsVisitor.walk(genericWhereClause)
+      genericRequirementVisitor.walk(genericWhereClause)
     }
 
     let declarationModifierVisitor = DeclarationModifierVisitor()
@@ -55,7 +55,7 @@ public final class TypealiasVisitor: SyntaxVisitor {
         name: name,
         genericParameters: genericTypeVisitor.genericParameters,
         initializer: node.initializer?.value.typeDescription,
-        genericRequirements: genericRequirementsVisitor.genericRequirements,
+        genericRequirements: genericRequirementVisitor.genericRequirements,
         modifiers: .init(declarationModifierVisitor.modifiers),
         parentType: parentType))
 


### PR DESCRIPTION
Nestable type declarations can have generic `where` requirements. This PR enables us to find those requirements.

Best reviewed commit-by-commit.