### PR TITLE
Expose Test Helpers as a library and stop exposing Commands

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,9 @@ let package = Package(
   ],
   products: [
     .executable(name: "swiftinspector", targets: ["SwiftInspector"]),
-    .library(name: "SwiftInspectorCommands", targets: ["SwiftInspectorCommands"]),
     .library(name: "SwiftInspectorAnalyzers", targets: ["SwiftInspectorAnalyzers"]),
     .library(name: "SwiftInspectorVisitors", targets: ["SwiftInspectorVisitors"]),
+    .library(name: "SwiftInspectorTestHelpers", targets: ["SwiftInspectorTestHelpers"]),
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.1")),


### PR DESCRIPTION
This PR just changes what we expose on SwiftInspector externally. We don't need to expose the Commands, but exposing the Test Library can be useful since there's some niceness there for making temp files.