### PR TITLE
Get SwiftInspector working with Xcode 12.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,13 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: self-hosted
+
     steps:
     # Checks-out the repo. More at: https://github.com/actions/checkout
     - uses: actions/checkout@v2
 
     - name: Select Xcode version
-      run: xcversion select 12.4
+      run: xcversion select 12.5
 
     - name: Build project
       run: swift build

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {
           "branch": null,
-          "revision": "7cd2f8cacc4d22f21bc0b2309c3b18acf7957b66",
-          "version": "1.2.0"
+          "revision": "f809deb30dc5c9d9b78c872e553261a61177721a",
+          "version": "2.0.0"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
         "state": {
           "branch": null,
-          "revision": "c228db5d2ad1b01ebc84435e823e6cca4e3db98b",
-          "version": "1.2.0"
+          "revision": "02b7a39a99c4da27abe03cab2053a9034379639f",
+          "version": "2.0.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "6abeb3f5c03beba2b9e4dbe20886e773b5b629b6",
-          "version": "8.0.4"
+          "revision": "7a54aaf19a8ef16f67787c260fda81ead7ba4d67",
+          "version": "9.0.1"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-syntax.git",
         "state": {
           "branch": null,
-          "revision": "844574d683f53d0737a9c6d706c3ef31ed2955eb",
-          "version": "0.50300.0"
+          "revision": "2fff9fc25cdc059379b6bd309377cfab45d8520c",
+          "version": "0.50400.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.1")),
     .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")),
-    .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.1")),
+    .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.1")),
     .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
     .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
   ],
   targets: [
-    .target(
+    .executableTarget(
       name: "SwiftInspector",
       dependencies: [
         "SwiftInspectorCommands",

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.3.1")),
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50300.0")),
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")),
     .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "8.0.1")),
     .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
   ],

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This project is currently under development and can have breaking API changes.
 
 ## Requirements
 
-- Swift 5.3
+- Swift 5.4
 
 ## Install
 

--- a/settings.xcconfig
+++ b/settings.xcconfig
@@ -1,1 +1,6 @@
+// For Quick to work with the generated Xcode project.
+// See https://github.com/Quick/Quick/issues/707 for more.
 CLANG_ENABLE_MODULES = YES;
+// For Nimble to work in Xcode 12.5.
+// See https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-release-notes for more
+ENABLE_TESTING_SEARCH_PATHS = YES;


### PR DESCRIPTION
Once this merges I'll release version `0.11.0`

Edit: OP said next release was `0.10.0` because I hadn't pulled latest `main` down!