### PR TITLE
Do not propagate properties to parents of nested types

### DIFF
--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -62,8 +62,6 @@ public final class PropertyVisitor: SyntaxVisitor {
     if visitTypeDeclarationChildren {
       return .visitChildren
     } else {
-      // We've encountered a nested type declaration.
-      // Skip it to avoid scanning a child type's properties.
       return .skipChildren
     }
   }
@@ -72,8 +70,6 @@ public final class PropertyVisitor: SyntaxVisitor {
     if visitTypeDeclarationChildren {
       return .visitChildren
     } else {
-      // We've encountered a nested type declaration.
-      // Skip it to avoid scanning a child type's properties.
       return .skipChildren
     }
   }
@@ -82,8 +78,22 @@ public final class PropertyVisitor: SyntaxVisitor {
     if visitTypeDeclarationChildren {
       return .visitChildren
     } else {
-      // We've encountered a nested type declaration.
-      // Skip it to avoid scanning a child type's properties.
+      return .skipChildren
+    }
+  }
+
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    if visitTypeDeclarationChildren {
+      return .visitChildren
+    } else {
+      return .skipChildren
+    }
+  }
+
+  public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+    if visitTypeDeclarationChildren {
+      return .visitChildren
+    } else {
       return .skipChildren
     }
   }

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -27,6 +27,13 @@ import SwiftSyntax
 
 public final class PropertyVisitor: SyntaxVisitor {
 
+  /// Initializes a property visitor.
+  /// - Parameter visitTypeDeclarationChildren: When `true`, this property visitor will visit the children of type declaration nodes.
+  public init(visitTypeDeclarationChildren: Bool = false) {
+    self.visitTypeDeclarationChildren = visitTypeDeclarationChildren
+    super.init()
+  }
+
   /// Information about each of the properties found on the type.
   private(set) var properties: [PropertyInfo] = []
 
@@ -52,6 +59,8 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   // MARK: Private
+
+  private let visitTypeDeclarationChildren: Bool
 
   private func findModifiers(from node: VariableDeclSyntax) -> PropertyInfo.Modifier {
     let modifiersString: [String] = node.children

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -58,6 +58,36 @@ public final class PropertyVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    if visitTypeDeclarationChildren {
+      return .visitChildren
+    } else {
+      // We've encountered a nested type declaration.
+      // Skip it to avoid scanning a child type's properties.
+      return .skipChildren
+    }
+  }
+
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    if visitTypeDeclarationChildren {
+      return .visitChildren
+    } else {
+      // We've encountered a nested type declaration.
+      // Skip it to avoid scanning a child type's properties.
+      return .skipChildren
+    }
+  }
+
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    if visitTypeDeclarationChildren {
+      return .visitChildren
+    } else {
+      // We've encountered a nested type declaration.
+      // Skip it to avoid scanning a child type's properties.
+      return .skipChildren
+    }
+  }
+
   // MARK: Private
 
   private let visitTypeDeclarationChildren: Bool

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -27,13 +27,6 @@ import SwiftSyntax
 
 public final class PropertyVisitor: SyntaxVisitor {
 
-  /// Initializes a property visitor.
-  /// - Parameter visitTypeDeclarationChildren: When `true`, this property visitor will visit the children of type declaration nodes.
-  public init(visitTypeDeclarationChildren: Bool = false) {
-    self.visitTypeDeclarationChildren = visitTypeDeclarationChildren
-    super.init()
-  }
-
   /// Information about each of the properties found on the type.
   private(set) var properties: [PropertyInfo] = []
 
@@ -59,28 +52,26 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
+    .skipChildren
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
+    .skipChildren
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
+    .skipChildren
   }
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
+    .skipChildren
   }
 
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
+    .skipChildren
   }
 
   // MARK: Private
-
-  private let visitTypeDeclarationChildren: Bool
 
   private func findModifiers(from node: VariableDeclSyntax) -> PropertyInfo.Modifier {
     let modifiersString: [String] = node.children

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -59,43 +59,23 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    if visitTypeDeclarationChildren {
-      return .visitChildren
-    } else {
-      return .skipChildren
-    }
+    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    if visitTypeDeclarationChildren {
-      return .visitChildren
-    } else {
-      return .skipChildren
-    }
+    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    if visitTypeDeclarationChildren {
-      return .visitChildren
-    } else {
-      return .skipChildren
-    }
+    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
   }
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    if visitTypeDeclarationChildren {
-      return .visitChildren
-    } else {
-      return .skipChildren
-    }
+    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
   }
 
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-    if visitTypeDeclarationChildren {
-      return .visitChildren
-    } else {
-      return .skipChildren
-    }
+    visitTypeDeclarationChildren ? .visitChildren : .skipChildren
   }
 
   // MARK: Private

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -960,6 +960,11 @@ final class NestableTypeVisitorSpec: QuickSpec {
           expect(property?.name) == "someFooFooClassProperty"
         }
 
+        it("does not find a property for FooEnum") {
+          let fooEnum = self.sut.enums.filter { $0.name == "FooEnum" }
+          expect(fooEnum.first?.properties).to(beEmpty())
+        }
+
         it("finds FooEnum.FooFooClass.BarFooFooEnum") {
           let matching = self.sut.enums.filter {
             $0.name == "BarFooFooEnum"

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -33,16 +33,14 @@ final class PropertyVisitorSpec: QuickSpec {
       var sut: PropertyVisitor!
 
       beforeEach {
-        sut = PropertyVisitor(visitTypeDeclarationChildren: true)
+        sut = PropertyVisitor()
       }
 
       context("when there are multiple properties on the same line") {
         let content = """
-        public final class FakeClass {
-          public var thing: String, foo: Int
-          let red, green, blue: Double
-          let seconds: Int, hours, years: Double
-        }
+        public var thing: String, foo: Int
+        let red, green, blue: Double
+        let seconds: Int, hours, years: Double
         """
 
         it("detects properties with different types") {
@@ -101,9 +99,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a static property") {
         let content = """
-        public struct FakeStruct {
-          public static var thing: String = "Hello, World"
-        }
+        public static var thing: String = "Hello, World"
         """
 
         it("detects the property") {
@@ -119,9 +115,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a static property in reverse order") {
         let content = """
-        public enum FakeEnum {
-          static public var thing: String = "Hello, World"
-        }
+        static public var thing: String = "Hello, World"
         """
 
         it("detects the property") {
@@ -137,9 +131,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a private property") {
         let content = """
-        public final class FakeClass {
-          private static var thing: String = "Hello, World"
-        }
+        private static var thing: String = "Hello, World"
         """
 
         it("detects the property") {
@@ -155,9 +147,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a public private(set) property") {
         let content = """
-        public final class FakeClass {
-          public private(set) var thing: String = "Hello, World"
-        }
+        public private(set) var thing: String = "Hello, World"
         """
 
         it("detects the property") {
@@ -173,9 +163,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a public internal(set) property") {
         let content = """
-        public final class FakeClass {
-          public internal(set) var thing: String = "Hello, World"
-        }
+        public internal(set) var thing: String = "Hello, World"
         """
 
         it("detects the property") {
@@ -191,9 +179,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a internal public(set) property") {
         let content = """
-        public final class FakeClass {
-          internal public(set) var thing: String = "Hello, World"
-        }
+        internal public(set) var thing: String = "Hello, World"
         """
 
         it("detects the property") {
@@ -209,9 +195,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a fileprivate property") {
         let content = """
-        public final class FakeClass {
-          fileprivate static var thing: String = "Hello, World"
-        }
+        fileprivate static var thing: String = "Hello, World"
         """
 
         it("detects the property") {
@@ -227,9 +211,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is no type annotation") {
         let content = """
-        public final class FakeClass {
-          private static var thing = "Hello, World"
-        }
+        private static var thing = "Hello, World"
         """
 
         it("detects the property with no type information") {
@@ -245,9 +227,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a property attribute") {
         let content = """
-        public final class FakeClass {
-          @objc public var thing = "Hello, World"
-        }
+        @objc public var thing = "Hello, World"
         """
 
         it("detects the property with no type information") {
@@ -261,7 +241,7 @@ final class PropertyVisitorSpec: QuickSpec {
         }
       }
 
-      context("when visitTypeDeclarationChildren is set to false") {
+      context("when there is a type declaration in content") {
         let content = """
         let hex: Int
         final class FakeClass {
@@ -280,10 +260,6 @@ final class PropertyVisitorSpec: QuickSpec {
           var timestamp: Int { 0 }
         }
         """
-
-        beforeEach {
-          sut = PropertyVisitor(visitTypeDeclarationChildren: false)
-        }
 
         it("detect properties outside the type declaration") {
           try sut.walkContent(content)

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -264,8 +264,14 @@ final class PropertyVisitorSpec: QuickSpec {
       context("when visitTypeDeclarationChildren is set to false") {
         let content = """
         let hex: Int
-        final struct FakeType {
+        final class FakeClass {
           let timestamp: Int
+        }
+        struct FakeStruct {
+          let timestamp: Int
+        }
+        enum FakeEnum {
+          var timestamp: Int { 0 }
         }
         """
 

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -38,7 +38,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there are multiple properties on the same line") {
         let content = """
-        public final class FakeType {
+        public final class FakeClass {
           public var thing: String, foo: Int
           let red, green, blue: Double
           let seconds: Int, hours, years: Double
@@ -101,7 +101,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a static property") {
         let content = """
-        public final class FakeType {
+        public struct FakeStruct {
           public static var thing: String = "Hello, World"
         }
         """
@@ -119,7 +119,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a static property in reverse order") {
         let content = """
-        public final class FakeType {
+        public enum FakeEnum {
           static public var thing: String = "Hello, World"
         }
         """
@@ -137,7 +137,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a private property") {
         let content = """
-        public final class FakeType {
+        public final class FakeClass {
           private static var thing: String = "Hello, World"
         }
         """
@@ -155,7 +155,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a public private(set) property") {
         let content = """
-        public final class FakeType {
+        public final class FakeClass {
           public private(set) var thing: String = "Hello, World"
         }
         """
@@ -173,7 +173,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a public internal(set) property") {
         let content = """
-        public final class FakeType {
+        public final class FakeClass {
           public internal(set) var thing: String = "Hello, World"
         }
         """
@@ -191,7 +191,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a internal public(set) property") {
         let content = """
-        public final class FakeType {
+        public final class FakeClass {
           internal public(set) var thing: String = "Hello, World"
         }
         """
@@ -209,7 +209,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a fileprivate property") {
         let content = """
-        public final class FakeType {
+        public final class FakeClass {
           fileprivate static var thing: String = "Hello, World"
         }
         """
@@ -227,7 +227,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is no type annotation") {
         let content = """
-        public final class FakeType {
+        public final class FakeClass {
           private static var thing = "Hello, World"
         }
         """
@@ -245,7 +245,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       context("when there is a property attribute") {
         let content = """
-        public final class FakeType {
+        public final class FakeClass {
           @objc public var thing = "Hello, World"
         }
         """

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -273,6 +273,12 @@ final class PropertyVisitorSpec: QuickSpec {
         enum FakeEnum {
           var timestamp: Int { 0 }
         }
+        protocol FakeProtocol {
+          var timestamp: Int { get }
+        }
+        extension FakeProtocol {
+          var timestamp: Int { 0 }
+        }
         """
 
         beforeEach {


### PR DESCRIPTION
We introduced a bug in #100 that I caught after the PR landed where a parent of a nested type that vended a property would have that property assigned to both the parent and nested type.

This PR fixes that issue. **Best reviewed in Files changed**.