### PR TITLE
[iOS] Use TypeDescription in PropertyInfo

### DIFF
--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -98,7 +98,8 @@ public final class PropertyVisitor: SyntaxVisitor {
     }
 
     // If there are no explicit modifiers, this is an internal property
-    if !modifier.contains(.public) &&
+    if !modifier.contains(.open) &&
+        !modifier.contains(.public) &&
         !modifier.contains(.fileprivate) &&
         !modifier.contains(.private)
     {
@@ -134,17 +135,18 @@ public struct PropertyInfo: Codable, Hashable, CustomDebugStringConvertible {
     public let rawValue: Int
 
     // general accessors
-    public static let `internal` = Modifier(rawValue: 1 << 0)
-    public static let `public` = Modifier(rawValue: 1 << 1)
-    public static let `private` = Modifier(rawValue: 1 << 2)
-    public static let `fileprivate` = Modifier(rawValue: 1 << 3)
+    public static let `open` = Modifier(rawValue: 1 << 0)
+    public static let `internal` = Modifier(rawValue: 1 << 1)
+    public static let `public` = Modifier(rawValue: 1 << 2)
+    public static let `private` = Modifier(rawValue: 1 << 3)
+    public static let `fileprivate` = Modifier(rawValue: 1 << 4)
     // set accessors
-    public static let privateSet = Modifier(rawValue: 1 << 4)
-    public static let internalSet = Modifier(rawValue: 1 << 5)
-    public static let publicSet = Modifier(rawValue: 1 << 6)
+    public static let privateSet = Modifier(rawValue: 1 << 5)
+    public static let internalSet = Modifier(rawValue: 1 << 6)
+    public static let publicSet = Modifier(rawValue: 1 << 7)
     // access control
-    public static let `instance` = Modifier(rawValue: 1 << 7)
-    public static let `static` = Modifier(rawValue: 1 << 8)
+    public static let `instance` = Modifier(rawValue: 1 << 8)
+    public static let `static` = Modifier(rawValue: 1 << 9)
 
     public init(rawValue: Int)  {
       self.rawValue = rawValue
@@ -152,6 +154,7 @@ public struct PropertyInfo: Codable, Hashable, CustomDebugStringConvertible {
 
     public init(stringValue: String) {
       switch stringValue {
+      case "open": self = .open
       case "public": self = .public
       case "private": self = .private
       case "fileprivate": self = .fileprivate

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -145,9 +145,9 @@ final class PropertyVisitorSpec: QuickSpec {
         }
       }
 
-      context("when there is a public private(set) property") {
+      context("when there is a open private(set) property") {
         let content = """
-        public private(set) var thing: String = "Hello, World"
+        open private(set) var thing: String = "Hello, World"
         """
 
         it("detects the property") {
@@ -156,7 +156,7 @@ final class PropertyVisitorSpec: QuickSpec {
             PropertyInfo(
               name: "thing",
               typeAnnotation: "String",
-              modifiers: [.public, .privateSet, .instance])
+              modifiers: [.open, .privateSet, .instance])
           ]
         }
       }

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -48,11 +48,11 @@ final class PropertyVisitorSpec: QuickSpec {
           let expected: [PropertyInfo] = [
             .init(
               name: "thing",
-              typeAnnotation: "String",
+              typeDescription: .simple(name: "String"),
               modifiers: [.public, .instance]),
             .init(
               name: "foo",
-              typeAnnotation: "Int",
+              typeDescription: .simple(name: "Int"),
               modifiers: [.public, .instance])
           ]
           expect(sut.properties).to(contain(expected))
@@ -63,15 +63,15 @@ final class PropertyVisitorSpec: QuickSpec {
           let expected: [PropertyInfo] = [
             .init(
               name: "green",
-              typeAnnotation: "Double",
+              typeDescription: .simple(name: "Double"),
               modifiers: [.internal, .instance]),
             .init(
               name: "red",
-              typeAnnotation: "Double",
+              typeDescription: .simple(name: "Double"),
               modifiers: [.internal, .instance]),
               .init(
                 name: "blue",
-                typeAnnotation: "Double",
+                typeDescription: .simple(name: "Double"),
                 modifiers: [.internal, .instance])
           ]
           expect(sut.properties).to(contain(expected))
@@ -82,15 +82,15 @@ final class PropertyVisitorSpec: QuickSpec {
           let expected: [PropertyInfo] = [
             .init(
               name: "seconds",
-              typeAnnotation: "Int",
+              typeDescription: .simple(name: "Int"),
               modifiers: [.internal, .instance]),
             .init(
               name: "hours",
-              typeAnnotation: "Double",
+              typeDescription: .simple(name: "Double"),
               modifiers: [.internal, .instance]),
             .init(
               name: "years",
-              typeAnnotation: "Double",
+              typeDescription: .simple(name: "Double"),
               modifiers: [.internal, .instance])
           ]
           expect(sut.properties).to(contain(expected))
@@ -107,7 +107,7 @@ final class PropertyVisitorSpec: QuickSpec {
           expect(sut.properties) == [
             PropertyInfo(
               name: "thing",
-              typeAnnotation: "String",
+              typeDescription: .simple(name: "String"),
               modifiers: [.public, .static])
           ]
         }
@@ -123,7 +123,7 @@ final class PropertyVisitorSpec: QuickSpec {
           expect(sut.properties) == [
             PropertyInfo(
               name: "thing",
-              typeAnnotation: "String",
+              typeDescription: .simple(name: "String"),
               modifiers: [.public, .static])
           ]
         }
@@ -139,7 +139,7 @@ final class PropertyVisitorSpec: QuickSpec {
           expect(sut.properties) == [
             PropertyInfo(
               name: "thing",
-              typeAnnotation: "String",
+              typeDescription: .simple(name: "String"),
               modifiers: [.private, .static])
           ]
         }
@@ -155,7 +155,7 @@ final class PropertyVisitorSpec: QuickSpec {
           expect(sut.properties) == [
             PropertyInfo(
               name: "thing",
-              typeAnnotation: "String",
+              typeDescription: .simple(name: "String"),
               modifiers: [.open, .privateSet, .instance])
           ]
         }
@@ -171,7 +171,7 @@ final class PropertyVisitorSpec: QuickSpec {
           expect(sut.properties) == [
             PropertyInfo(
               name: "thing",
-              typeAnnotation: "String",
+              typeDescription: .simple(name: "String"),
               modifiers: [.public, .internalSet, .instance])
           ]
         }
@@ -187,7 +187,7 @@ final class PropertyVisitorSpec: QuickSpec {
           expect(sut.properties) == [
             PropertyInfo(
               name: "thing",
-              typeAnnotation: "String",
+              typeDescription: .simple(name: "String"),
               modifiers: [.publicSet, .internal, .instance])
           ]
         }
@@ -203,7 +203,7 @@ final class PropertyVisitorSpec: QuickSpec {
           expect(sut.properties) == [
             PropertyInfo(
               name: "thing",
-              typeAnnotation: "String",
+              typeDescription: .simple(name: "String"),
               modifiers: [.fileprivate, .static])
           ]
         }
@@ -219,7 +219,7 @@ final class PropertyVisitorSpec: QuickSpec {
           expect(sut.properties) == [
             PropertyInfo(
               name: "thing",
-              typeAnnotation: nil,
+              typeDescription: nil,
               modifiers: [.private, .static])
           ]
         }
@@ -235,7 +235,7 @@ final class PropertyVisitorSpec: QuickSpec {
           expect(sut.properties) == [
             PropertyInfo(
               name: "thing",
-              typeAnnotation: nil,
+              typeDescription: nil,
               modifiers: [.public, .instance])
           ]
         }
@@ -266,7 +266,7 @@ final class PropertyVisitorSpec: QuickSpec {
           let expected: [PropertyInfo] = [
             .init(
               name: "hex",
-              typeAnnotation: "Int",
+              typeDescription: .simple(name: "Int"),
               modifiers: [.internal, .instance])
           ]
           expect(sut.properties).to(contain(expected))
@@ -277,7 +277,7 @@ final class PropertyVisitorSpec: QuickSpec {
           let notExpected: [PropertyInfo] = [
             .init(
               name: "timestamp",
-              typeAnnotation: "Int",
+              typeDescription: .simple(name: "Int"),
               modifiers: [.internal, .instance])
           ]
           expect(sut.properties).notTo(contain(notExpected))


### PR DESCRIPTION
**Easier to review commit-by-commit**

This PR moves us into using TypeDescription for PropertyInfo instead of a simple String so we can get more information about the type.

I noticed that we were not supporting `open` properties either, so I went ahead and added those too.