### PR TITLE
Do not use 'expect(...).to(throwAssertion())'

### DIFF
--- a/Sources/SwiftInspectorVisitors/AssertionFailure.swift
+++ b/Sources/SwiftInspectorVisitors/AssertionFailure.swift
@@ -1,0 +1,43 @@
+// Created by Dan Federman on 9/11/21.
+// Copyright © 2021 Dan Federman
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import Foundation
+
+/// Indicates that an internal confidence check failed.
+/// Posts the `AssertionFailure.notification` if `AssertionFailure.postNotification` is `true`, otherwise calls `Swift.assertionFailure`.
+/// Using this method instead of `Swift.assertionFailure` allows for testing that assertions are triggered.
+@inlinable public func assertionFailureOrPostNotification(_ message: @autoclosure () -> String = String(), file: StaticString = #file, line: UInt = #line) {
+  if AssertionFailure.postNotification {
+    NotificationCenter.default.post(AssertionFailure.notification)
+  } else {
+    assertionFailure(message(), file: file, line: line)
+  }
+}
+
+/// A collection of constants that enable testing assertion failures.
+public enum AssertionFailure {
+  /// The notification that is posted when `assertionFailureOrPostNotification` is called and `postNotification` is `true`.
+  public static let notification = Notification(name: Notification.Name(rawValue: "SwiftInspector.AssertionFailure"))
+  /// Set to `true` to post notifications in `assertionFailureOrPostNotification` rather than calling through to `Swift.assertionFailure`.
+  public static var postNotification = false
+}

--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -41,7 +41,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
 
     guard !hasFinishedParsingExtension else {
-      assertionFailure("Encountered more than one top-level extension. This is a usage error: a single ExtensionVisitor instance should start walking only over a node of type `ExtensionDeclSyntax`")
+      assertionFailureOrPostNotification("Encountered more than one top-level extension. This is a usage error: a single ExtensionVisitor instance should start walking only over a node of type `ExtensionDeclSyntax`")
       return .skipChildren
     }
 
@@ -90,7 +90,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     // We've encountered a protocol declaration, which can only be defined at the top-level. Something is wrong.
-    assertionFailure("Encountered a protocol. This is a usage error: a single ExtensionVisitor instance should start walking only over a node of type `ExtensionDeclSyntax`")
+    assertionFailureOrPostNotification("Encountered a protocol. This is a usage error: a single ExtensionVisitor instance should start walking only over a node of type `ExtensionDeclSyntax`")
     return .skipChildren
   }
 
@@ -119,7 +119,7 @@ public final class ExtensionVisitor: SyntaxVisitor {
 
     } else {
       // We've encountered a class declaration before encountering an extension declaration. Something is wrong.
-      assertionFailure("Encountered a top-level declaration. This is a usage error: a single ExtensionVisitor instance should start walking only over a node of type `ExtensionDeclSyntax`")
+      assertionFailureOrPostNotification("Encountered a top-level declaration. This is a usage error: a single ExtensionVisitor instance should start walking only over a node of type `ExtensionDeclSyntax`")
     }
     return .skipChildren
   }

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -77,13 +77,13 @@ public final class NestableTypeVisitor: SyntaxVisitor {
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
     // We've encountered a protocol declaration, which can only be defined at the top-level. Something is wrong.
-    assertionFailure("Encountered a protocol. This is a usage error: a single NestableTypeVisitor instance should start walking only over a nestable declaration syntax node")
+    assertionFailureOrPostNotification("Encountered a protocol. This is a usage error: a single NestableTypeVisitor instance should start walking only over a nestable declaration syntax node")
     return .skipChildren
   }
 
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
     // We've encountered an extension declaration, which can only be defined at the top-level. Something is wrong.
-    assertionFailure("Encountered an extension. This is a usage error: a single NestableTypeVisitor instance should start walking only over a nestable declaration syntax node")
+    assertionFailureOrPostNotification("Encountered an extension. This is a usage error: a single NestableTypeVisitor instance should start walking only over a nestable declaration syntax node")
     return .skipChildren
   }
 
@@ -92,7 +92,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
       !topLevelParsingTracker.hasFinishedParsing,
       let topLevelDeclarationName = topLevelDeclaration?.nestableInfo.name
     else {
-      assertionFailure("Encountered more than one top-level declaration. This is a usage error: a single NestableTypeVisitor instance should start walking only over a declaration syntax node")
+      assertionFailureOrPostNotification("Encountered more than one top-level declaration. This is a usage error: a single NestableTypeVisitor instance should start walking only over a declaration syntax node")
       return .skipChildren
     }
 
@@ -114,7 +114,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
   -> SyntaxVisitorContinueKind
   {
     guard !topLevelParsingTracker.hasFinishedParsing else {
-      assertionFailure("Encountered more than one top-level declaration. This is a usage error: a single NestableTypeVisitor instance should start walking only over a declaration syntax node")
+      assertionFailureOrPostNotification("Encountered more than one top-level declaration. This is a usage error: a single NestableTypeVisitor instance should start walking only over a declaration syntax node")
       return .skipChildren
     }
 

--- a/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
@@ -41,7 +41,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
 
     guard !hasFinishedParsingProtocol else {
-      assertionFailure("Encountered more than one top-level protocol. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
+      assertionFailureOrPostNotification("Encountered more than one top-level protocol. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
       return .skipChildren
     }
     let name = node.identifier.text
@@ -73,17 +73,17 @@ public final class ProtocolVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    assertionFailure("Encountered a top-level struct. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
+    assertionFailureOrPostNotification("Encountered a top-level struct. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
     return .skipChildren
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    assertionFailure("Encountered a top-level class. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
+    assertionFailureOrPostNotification("Encountered a top-level class. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
     return .skipChildren
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    assertionFailure("Encountered a top-level enum. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
+    assertionFailureOrPostNotification("Encountered a top-level enum. This is a usage error: a single ProtocolVisitor instance should start walking only over a node of type `ProtocolDeclSyntax`")
     return .skipChildren
   }
 

--- a/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
@@ -35,6 +35,11 @@ final class ExtensionVisitorSpec: QuickSpec {
   override func spec() {
     beforeEach {
       self.sut = ExtensionVisitor()
+      AssertionFailure.postNotification = true
+    }
+
+    afterEach {
+      AssertionFailure.postNotification = false
     }
 
     describe("visit(_:)") {
@@ -310,7 +315,7 @@ final class ExtensionVisitorSpec: QuickSpec {
             // The ExtensionVisitor is only meant to be used over a single extension.
             // Using a ExtensionVisitor over a block that has multiple top-level
             // extension is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -324,7 +329,7 @@ final class ExtensionVisitorSpec: QuickSpec {
             // The ExtensionVisitor is only meant to be used over a single extension.
             // Using a ExtensionVisitor over a block that has a top-level struct
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -338,7 +343,7 @@ final class ExtensionVisitorSpec: QuickSpec {
             // The ExtensionVisitor is only meant to be used over a single extension.
             // Using a ExtensionVisitor over a block that has a top-level class
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -352,7 +357,7 @@ final class ExtensionVisitorSpec: QuickSpec {
             // The ExtensionVisitor is only meant to be used over a single extension.
             // Using a ExtensionVisitor over a block that has a top-level enum
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
       }
@@ -366,7 +371,7 @@ final class ExtensionVisitorSpec: QuickSpec {
           // The ExtensionVisitor is only meant to be used over a single extension.
           // Using a ExtensionVisitor over a block that has a top-level struct
           // is API misuse.
-          expect(try self.sut.walkContent(content)).to(throwAssertion())
+          expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
         }
       }
 
@@ -379,7 +384,7 @@ final class ExtensionVisitorSpec: QuickSpec {
           // The ExtensionVisitor is only meant to be used over a single extension.
           // Using a ExtensionVisitor over a block that has a top-level class
           // is API misuse.
-          expect(try self.sut.walkContent(content)).to(throwAssertion())
+          expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
         }
       }
 
@@ -392,7 +397,7 @@ final class ExtensionVisitorSpec: QuickSpec {
           // The ExtensionVisitor is only meant to be used over a single extension.
           // Using a ExtensionVisitor over a block that has a top-level enum
           // is API misuse.
-          expect(try self.sut.walkContent(content)).to(throwAssertion())
+          expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
         }
       }
 
@@ -405,7 +410,7 @@ final class ExtensionVisitorSpec: QuickSpec {
           // The ExtensionVisitor is only meant to be used over a single extension.
           // Using a ExtensionVisitor over a block that has a top-level protocol
           // is API misuse.
-          expect(try self.sut.walkContent(content)).to(throwAssertion())
+          expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
         }
       }
     }

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -35,6 +35,11 @@ final class NestableTypeVisitorSpec: QuickSpec {
   override func spec() {
     beforeEach {
       self.sut = NestableTypeVisitor()
+      AssertionFailure.postNotification = true
+    }
+
+    afterEach {
+      AssertionFailure.postNotification = false
     }
 
     describe("visit(_:)") {
@@ -988,7 +993,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             // The ClassVisitor is only meant to be used over a single class.
             // Using a ClassVisitor over a block that has multiple top-level
             // classes is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -1002,7 +1007,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             // The ClassVisitor is only meant to be used over a single class.
             // Using a ClassVisitor over a block that has a top-level struct
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -1016,7 +1021,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             // The ClassVisitor is only meant to be used over a single class.
             // Using a ClassVisitor over a block that has a top-level enum
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
       }
@@ -1032,7 +1037,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             // The NestableTypeVisitor is only meant to be used over a single nestable type.
             // Using a NestableTypeVisitor over a block that has multiple top-level
             // structs is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -1046,7 +1051,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             // The NestableTypeVisitor is only meant to be used over a single nestable type.
             // Using a NestableTypeVisitor over a block that has a top-level class
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -1060,7 +1065,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             // The NestableTypeVisitor is only meant to be used over a single nestable type.
             // Using a NestableTypeVisitor over a block that has a top-level enum
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
       }
@@ -1076,7 +1081,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             // The NestableTypeVisitor is only meant to be used over a single nestable type.
             // Using a NestableTypeVisitor over a block that has multiple top-level
             // classes is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -1090,7 +1095,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             // The NestableTypeVisitor is only meant to be used over a single nestable type.
             // Using a NestableTypeVisitor over a block that has a top-level struct
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -1104,7 +1109,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             // The NestableTypeVisitor is only meant to be used over a single nestable type.
             // Using a NestableTypeVisitor over a block that has a top-level class
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
       }
@@ -1119,7 +1124,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
         // The NestableTypeVisitor is only meant to be used over a single nestable type.
         // Using a NestableTypeVisitor over a block that has a top-level protocol
         // is API misuse.
-        expect(try self.sut.walkContent(content)).to(throwAssertion())
+        expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
       }
     }
 
@@ -1132,7 +1137,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
         // The NestableTypeVisitor is only meant to be used over a single nestable type.
         // Using a NestableTypeVisitor over a block that has an extension
         // is API misuse.
-        expect(try self.sut.walkContent(content)).to(throwAssertion())
+        expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
       }
     }
 
@@ -1145,7 +1150,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
         // The NestableTypeVisitor is only meant to be used over a single nestable type.
         // Using a NestableTypeVisitor over a block that has a top-level typealias
         // is API misuse.
-        expect(try self.sut.walkContent(content)).to(throwAssertion())
+        expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
       }
     }
   }

--- a/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
@@ -35,6 +35,11 @@ final class ProtocolVisitorSpec: QuickSpec {
   override func spec() {
     beforeEach {
       self.sut = ProtocolVisitor()
+      AssertionFailure.postNotification = true
+    }
+
+    afterEach {
+      AssertionFailure.postNotification = false
     }
 
     describe("visit(_:)") {
@@ -221,7 +226,7 @@ final class ProtocolVisitorSpec: QuickSpec {
               // The ProtocolVisitor is only meant to be used over a single protocol.
               // Using a ProtocolVisitor over a block that has multiple top-level
               // protocols is API misuse.
-              expect(try self.sut.walkContent(content)).to(throwAssertion())
+              expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
             }
           }
 
@@ -235,7 +240,7 @@ final class ProtocolVisitorSpec: QuickSpec {
               // The ProtocolVisitor is only meant to be used over a single protocol.
               // Using a ProtocolVisitor over a block that has a top-level class
               // is API misuse.
-              expect(try self.sut.walkContent(content)).to(throwAssertion())
+              expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
             }
           }
 
@@ -249,7 +254,7 @@ final class ProtocolVisitorSpec: QuickSpec {
               // The ProtocolVisitor is only meant to be used over a single protocol.
               // Using a ProtocolVisitor over a block that has a top-level enum
               // is API misuse.
-              expect(try self.sut.walkContent(content)).to(throwAssertion())
+              expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
             }
           }
         }
@@ -263,7 +268,7 @@ final class ProtocolVisitorSpec: QuickSpec {
             // The ProtocolVisitor is only meant to be used over a single protocol.
             // Using a ProtocolVisitor over a block that has a top-level class
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -276,7 +281,7 @@ final class ProtocolVisitorSpec: QuickSpec {
             // The ProtocolVisitor is only meant to be used over a single protocol.
             // Using a ProtocolVisitor over a block that has a top-level class
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
 
@@ -289,7 +294,7 @@ final class ProtocolVisitorSpec: QuickSpec {
             // The ProtocolVisitor is only meant to be used over a single protocol.
             // Using a ProtocolVisitor over a block that has a top-level enum
             // is API misuse.
-            expect(try self.sut.walkContent(content)).to(throwAssertion())
+            expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
           }
         }
       }

--- a/Sources/SwiftInspectorVisitors/TypeDescription.swift
+++ b/Sources/SwiftInspectorVisitors/TypeDescription.swift
@@ -294,7 +294,7 @@ extension TypeSyntax {
       return .simple(name: "AnyObject")
 
     } else {
-      assertionFailure("TypeSyntax of unexpected type. Defaulting to `description`.")
+      assertionFailureOrPostNotification("TypeSyntax of unexpected type. Defaulting to `description`.")
       // The description is a source-accurate description of this node,
       // so it is a reasonable fallback.
       return .unknown(text: description)


### PR DESCRIPTION
This test method [crashes on M1 Macs](https://github.com/Quick/Nimble/blob/cfa125829821415bfaa9a43f03ee1cac6f743715/Sources/Nimble/Matchers/ThrowAssertion.swift#L124-L128), so instead of testing that we throw an assertion, this PR creates a way for us to test that we intend to assert.

Instead of calling `Swift.assertionFailure`, we'll now call `SwiftInspectorVisitors.assertionFailureOrPostNotification`, which will either assert or post a notification based on a static boolean.

The use of an static boolean with no threading barrier in this project is okay because the entire repo is single-threaded.

**We will need to merge this PR through a failing CodeCov check** because [we are expectedly not executing the `assertionFailure` line](https://app.codecov.io/gh/fdiaz/SwiftInspector/compare/106/diff#D3L33) in tests.