### PR TITLE
Remove trivia from paradigm

### DIFF
--- a/Sources/SwiftInspectorVisitors/PropertyInfo.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyInfo.swift
@@ -74,8 +74,9 @@ extension PropertyInfo {
     /// - Parameter initializerDescription: A source-accurate description of the initializer.
     case definedVariable(_ initializerDescription: String)
     /// A computed `var` property.
-    /// - Parameter codeBlockDesciption: A source-accurate description of the code block which computes the value.
-    case computedVariable(_ codeBlockDesciption: String)
+    /// - Parameter codeBlockDescription: A source-accurate description of the code block which computes the value
+    /// - Important: The code block description does not include the opening/closing brackets
+    case computedVariable(_ codeBlockDescription: String)
 
     // MARK: Lifecycle
 

--- a/Sources/SwiftInspectorVisitors/PropertyInfo.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyInfo.swift
@@ -67,15 +67,17 @@ extension PropertyInfo {
     case undefinedConstant
     /// A `let` property with an `=`.
     /// - Parameter initializerDescription: A source-accurate description of the initializer.
+    /// - Important: The initializer description does not include the equal sign.
     case definedConstant(_ initializerDescription: String)
     /// A  `var` property with no `=`.
     case undefinedVariable
     /// A `var ` property with an `=`.
     /// - Parameter initializerDescription: A source-accurate description of the initializer.
+    /// - Important: The initializer description does not include the equal sign.
     case definedVariable(_ initializerDescription: String)
     /// A computed `var` property.
     /// - Parameter codeBlockDescription: A source-accurate description of the code block which computes the value
-    /// - Important: The code block description does not include the opening/closing brackets
+    /// - Important: The code block description does not include the opening/closing braces.
     case computedVariable(_ codeBlockDescription: String)
 
     // MARK: Lifecycle

--- a/Sources/SwiftInspectorVisitors/PropertyInfo.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyInfo.swift
@@ -14,7 +14,7 @@ public struct PropertyInfo: Codable, Hashable, CustomDebugStringConvertible {
   public let paradigm: Paradigm
 
   public var debugDescription: String {
-    "\(modifiers.rawValue) \(name) \(typeDescription?.asSource ?? "")"
+    "\(modifiers.rawValue) \(name) \(typeDescription?.asSource ?? "") \(paradigm)"
   }
 }
 

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -168,7 +168,7 @@ public final class PropertyVisitor: SyntaxVisitor {
       let patternBindingSyntax = node.children.first?.as(PatternBindingSyntax.self),
       let codeBlockSyntax = patternBindingSyntax.children.compactMap({ $0.as(CodeBlockSyntax.self) }).first,
       let codeBlockList = codeBlockSyntax.children
-        .compactMap ({ $0.as(CodeBlockItemListSyntax.self) })
+        .compactMap({ $0.as(CodeBlockItemListSyntax.self) })
         .first
     else {
       return nil

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -32,7 +32,7 @@ public final class PropertyVisitor: SyntaxVisitor {
 
   public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
     let modifier = findModifiers(from: node)
-    let paradigm = findParamadigm(from: node)
+    let paradigm = findParadigm(from: node)
 
     var lastFoundType: TypeDescription?
     node.bindings.reversed().forEach { binding in
@@ -135,7 +135,7 @@ public final class PropertyVisitor: SyntaxVisitor {
     return typeSyntax.typeDescription
   }
 
-  private func findParamadigm(from node: VariableDeclSyntax) -> PropertyInfo.Paradigm {
+  private func findParadigm(from node: VariableDeclSyntax) -> PropertyInfo.Paradigm {
     switch findPropertyType(from: node) {
     case .constant:
       if let initializerDescription = findInitializerDescription(from: node.bindings) {
@@ -164,9 +164,16 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   private func findCodeBlockDescription(from node: PatternBindingListSyntax) -> String? {
-    let accessors = node.compactMap { $0.accessor }
-    assert(accessors.count <= 1, "A property should have at most one accessor.")
-    return accessors.first?.description
+    guard
+      let patternBindingSyntax = node.children.first?.as(PatternBindingSyntax.self),
+      let codeBlockSyntax = patternBindingSyntax.children.compactMap({ $0.as(CodeBlockSyntax.self) }).first,
+      let codeBlockList = codeBlockSyntax.children
+        .compactMap ({ $0.as(CodeBlockItemListSyntax.self) })
+        .first
+    else {
+      return nil
+    }
+    return codeBlockList.withoutTrivia().description
   }
 
   private func findPropertyType(from node: VariableDeclSyntax) -> PropertyType {

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -158,7 +158,7 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   private func findInitializerDescription(from node: PatternBindingListSyntax) -> String? {
-    let initializerClauseSyntaxes = node.compactMap { $0.initializer }
+    let initializerClauseSyntaxes = node.compactMap { $0.initializer?.withEqual(nil) }
     assert(initializerClauseSyntaxes.count <= 1, "A property should have at most one initializer.")
     return initializerClauseSyntaxes.first?.description
   }

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -373,7 +373,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "foo",
               typeDescription: nil,
               modifiers: [.internal, .instance],
-              paradigm: .computedVariable("{ Foo() }"))
+              paradigm: .computedVariable("Foo()"))
           ]
         }
       }

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -117,7 +117,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "thing",
               typeDescription: .simple(name: "String"),
               modifiers: [.public, .static],
-              paradigm: .definedVariable("= \"Hello, World\""))
+              paradigm: .definedVariable("\"Hello, World\""))
           ]
         }
       }
@@ -134,7 +134,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "thing",
               typeDescription: .simple(name: "String"),
               modifiers: [.public, .static],
-              paradigm: .definedVariable("= \"Hello, World\""))
+              paradigm: .definedVariable("\"Hello, World\""))
           ]
         }
       }
@@ -151,7 +151,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "thing",
               typeDescription: .simple(name: "String"),
               modifiers: [.private, .static],
-              paradigm: .definedVariable("= \"Hello, World\""))
+              paradigm: .definedVariable("\"Hello, World\""))
           ]
         }
       }
@@ -168,7 +168,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "thing",
               typeDescription: .simple(name: "String"),
               modifiers: [.open, .privateSet, .instance],
-              paradigm: .definedVariable("= \"Hello, World\""))
+              paradigm: .definedVariable("\"Hello, World\""))
           ]
         }
       }
@@ -185,7 +185,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "thing",
               typeDescription: .simple(name: "String"),
               modifiers: [.public, .internalSet, .instance],
-              paradigm: .definedVariable("= \"Hello, World\""))
+              paradigm: .definedVariable("\"Hello, World\""))
           ]
         }
       }
@@ -202,7 +202,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "thing",
               typeDescription: .simple(name: "String"),
               modifiers: [.publicSet, .internal, .instance],
-              paradigm: .definedVariable("= \"Hello, World\""))
+              paradigm: .definedVariable("\"Hello, World\""))
           ]
         }
       }
@@ -219,7 +219,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "thing",
               typeDescription: .simple(name: "String"),
               modifiers: [.fileprivate, .static],
-              paradigm: .definedVariable("= \"Hello, World\""))
+              paradigm: .definedVariable("\"Hello, World\""))
           ]
         }
       }
@@ -236,7 +236,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "thing",
               typeDescription: nil,
               modifiers: [.private, .static],
-              paradigm: .definedVariable("= \"Hello, World\""))
+              paradigm: .definedVariable("\"Hello, World\""))
           ]
         }
       }
@@ -253,7 +253,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "thing",
               typeDescription: nil,
               modifiers: [.public, .instance],
-              paradigm: .definedVariable("= \"Hello, World\""))
+              paradigm: .definedVariable("\"Hello, World\""))
           ]
         }
       }
@@ -288,7 +288,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "foo",
               typeDescription: nil,
               modifiers: [.internal, .instance],
-              paradigm: .definedConstant("= Foo()"))
+              paradigm: .definedConstant("Foo()"))
           ]
         }
 
@@ -304,7 +304,7 @@ final class PropertyVisitorSpec: QuickSpec {
                 name: "foo",
                 typeDescription: nil,
                 modifiers: [.internal, .instance],
-                paradigm: .definedConstant("= Foo() = Foo()"))
+                paradigm: .definedConstant("Foo() = Foo()"))
             ]
           }
         }
@@ -339,7 +339,7 @@ final class PropertyVisitorSpec: QuickSpec {
               name: "foo",
               typeDescription: nil,
               modifiers: [.internal, .instance],
-              paradigm: .definedVariable("= Foo()"))
+              paradigm: .definedVariable("Foo()"))
           ]
         }
 
@@ -355,7 +355,7 @@ final class PropertyVisitorSpec: QuickSpec {
                 name: "foo",
                 typeDescription: nil,
                 modifiers: [.internal, .instance],
-                paradigm: .definedVariable("= { Foo() }()"))
+                paradigm: .definedVariable("{ Foo() }()"))
             ]
           }
         }


### PR DESCRIPTION
Acting on [this piece of feedback](https://github.com/fdiaz/SwiftInspector/pull/110#discussion_r710339525) I gave to @bachand PR

This simplifies the paradigm and only gives us the information about the type rather than the equals sign and the braces sign for computed properties.

cc @dfed 