### PR TITLE
Update `PropertyInfo.Paradigm` to handle properties in protocols

### DIFF
--- a/Sources/SwiftInspectorVisitors/PropertyInfo.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyInfo.swift
@@ -79,6 +79,8 @@ extension PropertyInfo {
     /// - Parameter codeBlockDescription: A source-accurate description of the code block which computes the value
     /// - Important: The code block description does not include the opening/closing braces.
     case computedVariable(_ codeBlockDescription: String)
+    /// A property on a protocol that is only gettable.
+    case protocolGetter
 
     // MARK: Lifecycle
 
@@ -104,6 +106,9 @@ extension PropertyInfo {
         let codeBlockDesciption = try values.decode(String.self, forKey: .codeBlockDesciption)
         self = .computedVariable(codeBlockDesciption)
 
+      case Self.protocolGetterValue:
+        self = .protocolGetter
+
       default:
         throw CodingError.unknownCase
       }
@@ -123,6 +128,8 @@ extension PropertyInfo {
         try container.encode(initializerDescription, forKey: .initializerDescription)
       case .computedVariable(let codeBlockDesciption):
         try container.encode(codeBlockDesciption, forKey: .codeBlockDesciption)
+      case .protocolGetter:
+        break
       }
     }
 
@@ -149,6 +156,7 @@ extension PropertyInfo {
     private static let undefinedVariableValue = 2
     private static let definedVariableValue = 3
     private static let computedVariableValue = 4
+    private static let protocolGetterValue = 5
 
     private var caseValue: Int {
       switch self {
@@ -157,6 +165,7 @@ extension PropertyInfo {
       case .undefinedVariable: return Self.undefinedVariableValue
       case .definedVariable: return Self.definedVariableValue
       case .computedVariable: return Self.computedVariableValue
+      case .protocolGetter: return Self.protocolGetterValue
       }
     }
   }

--- a/Sources/SwiftInspectorVisitors/PropertyInfo.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyInfo.swift
@@ -100,6 +100,8 @@ extension PropertyInfo {
     case computedVariable(_ codeBlockDescription: String)
     /// A property on a protocol that is only gettable.
     case protocolGetter
+    /// A property on a protocol that is gettable and settable.
+    case protocolGetterAndSetter
 
     // MARK: Lifecycle
 
@@ -128,6 +130,9 @@ extension PropertyInfo {
       case Self.protocolGetterValue:
         self = .protocolGetter
 
+      case Self.protocolGetterAndSetterValue:
+        self = .protocolGetterAndSetter
+
       default:
         throw CodingError.unknownCase
       }
@@ -148,6 +153,8 @@ extension PropertyInfo {
       case .computedVariable(let codeBlockDesciption):
         try container.encode(codeBlockDesciption, forKey: .codeBlockDesciption)
       case .protocolGetter:
+        break
+      case .protocolGetterAndSetter:
         break
       }
     }
@@ -176,6 +183,7 @@ extension PropertyInfo {
     private static let definedVariableValue = 3
     private static let computedVariableValue = 4
     private static let protocolGetterValue = 5
+    private static let protocolGetterAndSetterValue = 6
 
     private var caseValue: Int {
       switch self {
@@ -185,6 +193,7 @@ extension PropertyInfo {
       case .definedVariable: return Self.definedVariableValue
       case .computedVariable: return Self.computedVariableValue
       case .protocolGetter: return Self.protocolGetterValue
+      case .protocolGetterAndSetter: return Self.protocolGetterAndSetterValue
       }
     }
   }

--- a/Sources/SwiftInspectorVisitors/PropertyInfo.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyInfo.swift
@@ -1,5 +1,24 @@
 // Created by Michael Bachand on 9/15/21.
-// Copyright © 2021 Airbnb Inc. All rights reserved.
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 // MARK: - PropertyInfo
 

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -148,13 +148,17 @@ public final class PropertyVisitor: SyntaxVisitor {
         return .undefinedConstant
       }
     case .variable:
-      if let initializerDescription = patternBindingListVisitor.initializerDescription {
+      let initializerDescription = patternBindingListVisitor.initializerDescription
+      let codeBlockDescription = patternBindingListVisitor.codeBlockDescription
+      let protocolRequirement = patternBindingListVisitor.protocolRequirement
+
+      if let initializerDescription = initializerDescription {
         return .definedVariable(initializerDescription)
       }
-      else if let codeBlockDescription = patternBindingListVisitor.codeBlockDescription {
+      else if let codeBlockDescription = codeBlockDescription {
         return .computedVariable(codeBlockDescription)
       }
-      else if let protocolRequirement = patternBindingListVisitor.protocolRequirement {
+      else if let protocolRequirement = protocolRequirement {
         switch protocolRequirement {
         case .gettable: return .protocolGetter
         }

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -140,8 +140,7 @@ public final class PropertyVisitor: SyntaxVisitor {
     patternBindingListVisitor.walk(node.bindings)
 
     assert(
-      patternBindingListVisitor.validateExtractedData(),
-      "The data extracted from the pattern binding does not match our expectations")
+      patternBindingListVisitor.validateExtractedData(), "The data extracted from the pattern binding does not match our expectations")
 
     switch findPropertyType(from: node) {
     case .constant:

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -156,7 +156,7 @@ public final class PropertyVisitor: SyntaxVisitor {
         initializerDescription as Any?,
         codeBlockDescription as Any?,
         protocolRequirement as Any?,
-      ].compactMap { $0 }.count >= 1, "We never expect a property to have more than one of these details")
+      ].compactMap { $0 }.count <= 1, "We never expect a property to have more than one of these details")
 
       if let initializerDescription = initializerDescription {
         return .definedVariable(initializerDescription)

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -152,11 +152,9 @@ public final class PropertyVisitor: SyntaxVisitor {
       let codeBlockDescription = patternBindingListVisitor.codeBlockDescription
       let protocolRequirement = patternBindingListVisitor.protocolRequirement
 
-      assert([
-        initializerDescription as Any?,
-        codeBlockDescription as Any?,
-        protocolRequirement as Any?,
-      ].compactMap { $0 }.count <= 1, "We never expect a property to have more than one of these details")
+      assert(
+        patternBindingListVisitor.validateExtractedData(),
+        "The data extracted from the pattern binding does not match our expectations")
 
       if let initializerDescription = initializerDescription {
         return .definedVariable(initializerDescription)
@@ -214,5 +212,14 @@ private final class PatternBindingListVisitor: SyntaxVisitor {
   public override func visit(_ node: AccessorDeclSyntax) -> SyntaxVisitorContinueKind {
     if node.accessorKind.text == "get" { protocolRequirement = .gettable }
     return .skipChildren
+  }
+
+  func validateExtractedData() -> Bool {
+    let extractedData: [Any?] = [
+      initializerDescription,
+      codeBlockDescription,
+      protocolRequirement,
+    ]
+    return extractedData.compactMap { $0 }.count <= 1
   }
 }

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -152,6 +152,12 @@ public final class PropertyVisitor: SyntaxVisitor {
       let codeBlockDescription = patternBindingListVisitor.codeBlockDescription
       let protocolRequirement = patternBindingListVisitor.protocolRequirement
 
+      assert([
+        initializerDescription as Any?,
+        codeBlockDescription as Any?,
+        protocolRequirement as Any?,
+      ].compactMap { $0 }.count >= 1, "We never expect a property to have more than one of these details")
+
       if let initializerDescription = initializerDescription {
         return .definedVariable(initializerDescription)
       }

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyInfoSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyInfoSpec.swift
@@ -75,6 +75,13 @@ final class PropertyInfoParadigmSpec: QuickSpec {
     }
     """.data(using: .utf8)!
 
+  let protocolGetterAndSetterTestCase = PropertyInfo.Paradigm.protocolGetterAndSetter
+  let protocolGetterAndSetterTestCaseData = """
+    {
+      "caseValue": 6
+    }
+    """.data(using: .utf8)!
+
   override func spec() {
     describe("When decoding previously persisted PropertyInfo.Paradigm data") {
       let decoder = JSONDecoder()
@@ -118,6 +125,13 @@ final class PropertyInfoParadigmSpec: QuickSpec {
         it("decodes the encoded paradigm") {
           expect(try decoder.decode(PropertyInfo.Paradigm.self, from: self.protocolGetterTestCaseData))
             == self.protocolGetterTestCase
+        }
+      }
+
+      context("that represents a protocol getter and setter property") {
+        it("decodes the encoded paradigm") {
+          expect(try decoder.decode(PropertyInfo.Paradigm.self, from: self.protocolGetterAndSetterTestCaseData))
+            == self.protocolGetterAndSetterTestCase
         }
       }
 
@@ -178,6 +192,13 @@ final class PropertyInfoParadigmSpec: QuickSpec {
         it("successfully decodes the data") {
           expect(try decoder.decode(PropertyInfo.Paradigm.self, from: try encoder.encode(self.protocolGetterTestCase)))
             == self.protocolGetterTestCase
+        }
+      }
+
+      context("utilizing a protocol getter and setter") {
+        it("successfully decodes the data") {
+          expect(try decoder.decode(PropertyInfo.Paradigm.self, from: try encoder.encode(self.protocolGetterAndSetterTestCase)))
+            == self.protocolGetterAndSetterTestCase
         }
       }
     }

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyInfoSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyInfoSpec.swift
@@ -1,5 +1,24 @@
 // Created by Michael Bachand on 9/15/21.
-// Copyright © 2021 Airbnb Inc. All rights reserved.
+//
+// Distributed under the MIT License
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 import Foundation
 import Nimble

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyInfoSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyInfoSpec.swift
@@ -49,6 +49,13 @@ final class PropertyInfoParadigmSpec: QuickSpec {
     }
     """.data(using: .utf8)!
 
+  let protocolGetterTestCase = PropertyInfo.Paradigm.protocolGetter
+  let protocolGetterTestCaseData = """
+    {
+      "caseValue": 5
+    }
+    """.data(using: .utf8)!
+
   override func spec() {
     describe("When decoding previously persisted PropertyInfo.Paradigm data") {
       let decoder = JSONDecoder()
@@ -81,10 +88,17 @@ final class PropertyInfoParadigmSpec: QuickSpec {
         }
       }
 
-      context("that represents a computed property property") {
+      context("that represents a computed variable property") {
         it("decodes the encoded paradigm") {
           expect(try decoder.decode(PropertyInfo.Paradigm.self, from: self.computedVariableTestCaseData))
             == self.computedVariableTestCase
+        }
+      }
+
+      context("that represents a protocol getter property") {
+        it("decodes the encoded paradigm") {
+          expect(try decoder.decode(PropertyInfo.Paradigm.self, from: self.protocolGetterTestCaseData))
+            == self.protocolGetterTestCase
         }
       }
 
@@ -138,6 +152,13 @@ final class PropertyInfoParadigmSpec: QuickSpec {
         it("successfully decodes the data") {
           expect(try decoder.decode(PropertyInfo.Paradigm.self, from: try encoder.encode(self.computedVariableTestCase)))
             == self.computedVariableTestCase
+        }
+      }
+
+      context("utilizing a protocol getter") {
+        it("successfully decodes the data") {
+          expect(try decoder.decode(PropertyInfo.Paradigm.self, from: try encoder.encode(self.protocolGetterTestCase)))
+            == self.protocolGetterTestCase
         }
       }
     }

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -353,7 +353,7 @@ final class PropertyVisitorSpec: QuickSpec {
           }
           """
 
-          fit("has expected paradigm") {
+          it("has expected paradigm") {
             try protocolVisitor.walkContent(content)
             expect(sut.properties.first?.paradigm).to(equal(.protocolGetter))
           }

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -366,10 +366,9 @@ final class PropertyVisitorSpec: QuickSpec {
           }
           """
 
-          // We will figure out how to implement this when we need it.
-          it("is not found") {
+          it("has expected paradigm") {
             try protocolVisitor.walkContent(content)
-            expect(sut.properties).to(beEmpty())
+            expect(sut.properties.first?.paradigm).to(equal(.protocolGetterAndSetter))
           }
         }
       }

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -342,7 +342,7 @@ final class PropertyVisitorSpec: QuickSpec {
           var foo: Foo { get }
           """
 
-          it("has expected paradigm") {
+          fit("has expected paradigm") {
             try sut.walkContent(content)
             expect(sut.properties.first?.paradigm).to(equal(.protocolGetter))
           }

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -336,6 +336,30 @@ final class PropertyVisitorSpec: QuickSpec {
         }
       }
 
+      context("when the property is part of a protocol definition") {
+        context("and is only gettable") {
+          let content = """
+          var foo: Foo { get }
+          """
+
+          it("is treated as an undefined variable") {
+            try sut.walkContent(content)
+            expect(sut.properties.first?.paradigm).to(equal(.undefinedVariable))
+          }
+        }
+
+        context("and is gettable and settable") {
+          let content = """
+          var foo: Foo { get set }
+          """
+
+          it("is not found") {
+            try sut.walkContent(content)
+            expect(sut.properties).to(beEmpty())
+          }
+        }
+      }
+
       context("when there is a type declaration in content") {
         let content = """
         let hex: Int

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -348,7 +348,9 @@ final class PropertyVisitorSpec: QuickSpec {
 
         context("and is only gettable") {
           let content = """
-          var foo: Foo { get }
+          protocol MyProtocol {
+            var foo: Foo { get }
+          }
           """
 
           fit("has expected paradigm") {
@@ -359,7 +361,9 @@ final class PropertyVisitorSpec: QuickSpec {
 
         context("and is gettable and settable") {
           let content = """
-          var foo: Foo { get set }
+          protocol MyProtocol {
+            var foo: Foo { get set }
+          }
           """
 
           // We will figure out how to implement this when we need it.

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -342,9 +342,9 @@ final class PropertyVisitorSpec: QuickSpec {
           var foo: Foo { get }
           """
 
-          it("is treated as an undefined variable") {
+          it("has expected paradigm") {
             try sut.walkContent(content)
-            expect(sut.properties.first?.paradigm).to(equal(.undefinedVariable))
+            expect(sut.properties.first?.paradigm).to(equal(.protocolGetter))
           }
         }
 
@@ -353,6 +353,7 @@ final class PropertyVisitorSpec: QuickSpec {
           var foo: Foo { get set }
           """
 
+          // We will figure out how to implement this when we need it.
           it("is not found") {
             try sut.walkContent(content)
             expect(sut.properties).to(beEmpty())


### PR DESCRIPTION
Best reviewed in Files Changed view.

This PR builds on https://github.com/fdiaz/SwiftInspector/pull/110 to add a paradigm for properties in protocols.

We start by documenting the current behavior.

Then we add ways to strongly encode these cases into `PropertyInfo.Paradigm`.

- `var foo: Foo { get }` -> `PropertyInfo.Paradigm.protocolGetter`
- `var foo: Foo { get set }` -> `PropertyInfo.Paradigm.protocolGetterAndSetter`

`var foo: Foo { set }` is not valid Swift code.

@fdiaz cc: @dfed 