### PR TITLE
Remove patch from codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,5 @@
 coverage:
   status:
-    # PRs only
-    patch:
-      default:
-        threshold: 0.25%
     project:
       default:
         threshold: 0.25%


### PR DESCRIPTION
Based on the [cloudcov documentation](https://docs.codecov.com/docs/commit-status#patch-status) and what @bachand mentioned [here](https://github.com/fdiaz/SwiftInspector/pull/120#issuecomment-1048231079) we should remove the patch from the coverage enforcement. 