### PR TITLE
Add information about function names and return types

### DIFF
--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -63,12 +63,16 @@ public final class ExtensionVisitor: SyntaxVisitor {
     let propertyVisitor = PropertyVisitor()
     propertyVisitor.walk(node.members)
 
+    let functionDeclarationVisitor = FunctionDeclarationVisitor()
+    functionDeclarationVisitor.walk(node)
+
     extensionInfo = ExtensionInfo(
       typeDescription: node.extendedType.typeDescription,
       inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
       genericRequirements: genericRequirementVisitor.genericRequirements,
       modifiers: .init(declarationModifierVisitor.modifiers),
-      properties: propertyVisitor.properties)
+      properties: propertyVisitor.properties,
+      functionDeclarations: functionDeclarationVisitor.functionDeclarations)
     return .visitChildren
   }
 
@@ -133,4 +137,5 @@ public struct ExtensionInfo: Codable, Hashable {
   public private(set) var genericRequirements: [GenericRequirement]
   public let modifiers: Set<String>
   public let properties: [PropertyInfo]
+  public let functionDeclarations: [FunctionDeclarationInfo]
 }

--- a/Sources/SwiftInspectorVisitors/FileVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FileVisitor.swift
@@ -55,6 +55,13 @@ public final class FileVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    let visitor = FunctionDeclarationVisitor()
+    visitor.walk(node)
+    fileInfo.appendFreeFunctions(visitor.functionDeclarations)
+    return .skipChildren
+  }
+
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
     visitNestableDeclaration(node: node)
   }
@@ -119,6 +126,7 @@ public struct FileInfo: Codable, Hashable {
   public private(set) var enums = [EnumInfo]()
   public private(set) var extensions = [ExtensionInfo]()
   public private(set) var typealiases = [TypealiasInfo]()
+  public private(set) var freeFunctions = [FunctionDeclarationInfo]()
 
   mutating func appendImports(_ imports: [ImportStatement]) {
     self.imports += imports
@@ -140,5 +148,8 @@ public struct FileInfo: Codable, Hashable {
   }
   mutating func appendTypealiases(_ typealiases: [TypealiasInfo]) {
     self.typealiases += typealiases
+  }
+  mutating func appendFreeFunctions(_ functionDeclarations: [FunctionDeclarationInfo]) {
+    freeFunctions.append(contentsOf: functionDeclarations)
   }
 }

--- a/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
@@ -1,0 +1,28 @@
+import SwiftSyntax
+
+public final class FunctionDeclarationVisitor: SyntaxVisitor {
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    let name = node.identifier.withoutTrivia().description
+    let functionSignatureVisitor = FunctionSignatureVisitor()
+    functionSignatureVisitor.walk(node)
+    let info = FunctionDeclarationInfo(name: name, returnType: functionSignatureVisitor.returnType)
+    functionDeclarations.append(info)
+    return .skipChildren
+  }
+
+  public var functionDeclarations: [FunctionDeclarationInfo] = []
+}
+
+fileprivate final class FunctionSignatureVisitor: SyntaxVisitor {
+  override func visit(_ node: ReturnClauseSyntax) -> SyntaxVisitorContinueKind {
+    returnType = node.returnType.typeDescription
+    return .skipChildren
+  }
+
+  fileprivate var returnType: TypeDescription?
+}
+
+public struct FunctionDeclarationInfo: Codable, Hashable {
+  public let name: String
+  public let returnType: TypeDescription?
+}

--- a/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
@@ -25,4 +25,5 @@ fileprivate final class FunctionSignatureVisitor: SyntaxVisitor {
 public struct FunctionDeclarationInfo: Codable, Hashable {
   public let name: String
   public let returnType: TypeDescription?
+  // TODO: Add parameters and argument labels
 }

--- a/Sources/SwiftInspectorVisitors/NestableTypeInfo.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeInfo.swift
@@ -30,6 +30,7 @@ public struct NestableTypeInfo: Codable, Hashable {
   public let genericParameters: [GenericParameter]
   public let genericRequirements: [GenericRequirement]
   public let properties: [PropertyInfo]
+  public let functionDeclarations: [FunctionDeclarationInfo]
 }
 
 public typealias ClassInfo = NestableTypeInfo

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -159,6 +159,10 @@ public final class NestableTypeVisitor: SyntaxVisitor {
         genericRequirementVisitor.walk(genericWhereClause)
       }
 
+      let visitor = FunctionDeclarationVisitor()
+      visitor.walk(node)
+      let functionDeclarations = visitor.functionDeclarations
+
       let propertyVisitor = PropertyVisitor()
       propertyVisitor.walk(node.members)
 
@@ -170,7 +174,8 @@ public final class NestableTypeVisitor: SyntaxVisitor {
           modifiers: Set(declarationModifierVisitor.modifiers),
           genericParameters: genericParameterVisitor.genericParameters,
           genericRequirements: genericRequirementVisitor.genericRequirements,
-          properties: propertyVisitor.properties))
+          properties: propertyVisitor.properties,
+          functionDeclarations: functionDeclarations))
 
       return .visitChildren
     }

--- a/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ProtocolVisitor.swift
@@ -35,7 +35,8 @@ public final class ProtocolVisitor: SyntaxVisitor {
       genericRequirements: genericRequirements ?? [],
       modifiers: modifiers ?? .init(),
       innerTypealiases: typealiases,
-      properties: properties)
+      properties: properties,
+      functionDeclarations: functionDeclarations)
   }
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
@@ -114,6 +115,16 @@ public final class ProtocolVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    let visitor = FunctionDeclarationVisitor()
+    visitor.walk(node)
+    let functions = visitor.functionDeclarations
+    functionDeclarations.append(contentsOf: functions)
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
   // MARK: Private
 
   private var hasFinishedParsingProtocol = false
@@ -124,6 +135,7 @@ public final class ProtocolVisitor: SyntaxVisitor {
   private var associatedtypes: [AssociatedtypeInfo] = []
   private var typealiases: [TypealiasInfo] = []
   private var properties: [PropertyInfo] = []
+  private var functionDeclarations: [FunctionDeclarationInfo] = []
   private var parentType: TypeDescription?
 }
 
@@ -135,4 +147,5 @@ public struct ProtocolInfo: Codable, Hashable {
   public let modifiers: Set<String>
   public let innerTypealiases: [TypealiasInfo]
   public let properties: [PropertyInfo]
+  public let functionDeclarations: [FunctionDeclarationInfo]
 }

--- a/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
@@ -160,7 +160,10 @@ final class ExtensionVisitorSpec: QuickSpec {
               }
 
               typealias TestClassTypeAlias = TestClass
-            }
+
+              func some() -> Int {
+                1
+              }
             """
 
           try? self.sut.walkContent(content)
@@ -301,6 +304,11 @@ final class ExtensionVisitorSpec: QuickSpec {
               && $0.initializer?.asSource == "TestClass"
           }
           expect(matching.count) == 1
+        }
+
+        it("finds the function") {
+          let functionDeclaration = self.sut.extensionInfo?.functionDeclarations.first
+          expect(functionDeclaration?.name) == "some"
         }
       }
 

--- a/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ExtensionVisitorSpec.swift
@@ -164,6 +164,7 @@ final class ExtensionVisitorSpec: QuickSpec {
               func some() -> Int {
                 1
               }
+            }
             """
 
           try? self.sut.walkContent(content)

--- a/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FileVisitorSpec.swift
@@ -77,6 +77,14 @@ final class FileVisitorSpec: QuickSpec {
               }
 
               typealias SortableSet<Element: Hashable & Comparable> = Set<Element>
+
+              func foo() -> String {
+                "Bar"
+              }
+
+              func bar() -> String {
+                "Foo"
+              }
               """
 
           try? self.sut.walkContent(content)
@@ -269,6 +277,12 @@ final class FileVisitorSpec: QuickSpec {
               && $0.genericParameters.first?.inheritsFrom?.asSource == "Hashable & Comparable"
           }
           expect(matching.count) == 1
+        }
+
+        it("finds the free functions") {
+          let functionNames = self.sut.fileInfo.freeFunctions.map(\.name)
+          expect(functionNames).to(contain("foo"))
+          expect(functionNames).to(contain("bar"))
         }
       }
     }

--- a/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
@@ -33,7 +33,7 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
         }
       }
 
-      context("a function with a return value") {
+      context("a function without a return value") {
         beforeEach {
           let content = """
             func printWithoutCounting(string: String) {
@@ -75,7 +75,7 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
         it("finds the function name") {
           expect(self.sut.functionDeclarations.first?.name) == "minMax"
         }
-        it("sets the return type as nil") {
+        it("finds the tuple return value") {
           expect(self.sut.functionDeclarations.first?.returnType) == .tuple([.simple(name: "Int"), .simple(name: "Int")])
         }
 
@@ -105,7 +105,7 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
           try? self.sut.walkContent(content)
         }
 
-        it("finds the correct amount of functions") {
+        it("finds the correct number of functions") {
           expect(self.sut.functionDeclarations.count) == 2
         }
         it("finds the first function") {

--- a/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Nimble
+import Quick
+import SwiftInspectorTestHelpers
+import SwiftInspectorVisitors
+
+final class FunctionDeclarationVisitorSpec: QuickSpec {
+  private var sut: FunctionDeclarationVisitor!
+
+  override func spec() {
+    beforeEach {
+      self.sut = FunctionDeclarationVisitor()
+    }
+
+    describe("visit(_:)") {
+      context("a function with a return value") {
+        beforeEach {
+          let content = """
+            func greet(person: String) -> String {
+                let greeting = "Hello, " + person + "!"
+                return greeting
+            }
+            """
+
+          try? self.sut.walkContent(content)
+        }
+
+        it("finds the function name") {
+          expect(self.sut.functionDeclarations.first?.name) == "greet"
+        }
+        it("finds the return type") {
+          expect(self.sut.functionDeclarations.first?.returnType) == TypeDescription.simple(name: "String")
+        }
+      }
+
+      context("a function with a return value") {
+        beforeEach {
+          let content = """
+            func printWithoutCounting(string: String) {
+                let _ = printAndCount(string: string)
+            }
+            """
+
+          try? self.sut.walkContent(content)
+        }
+
+        it("finds the function name") {
+          expect(self.sut.functionDeclarations.first?.name) == "printWithoutCounting"
+        }
+        it("sets the return type as nil") {
+          expect(self.sut.functionDeclarations.first?.returnType).to(beNil())
+        }
+      }
+
+      context("a function with multiple return values") {
+        beforeEach {
+          let content = """
+            func minMax(array: [Int]) -> (min: Int, max: Int) {
+                var currentMin = array[0]
+                var currentMax = array[0]
+                for value in array[1..<array.count] {
+                    if value < currentMin {
+                        currentMin = value
+                    } else if value > currentMax {
+                        currentMax = value
+                    }
+                }
+                return (currentMin, currentMax)
+            }
+            """
+
+          try? self.sut.walkContent(content)
+        }
+
+        it("finds the function name") {
+          expect(self.sut.functionDeclarations.first?.name) == "minMax"
+        }
+        it("sets the return type as nil") {
+          expect(self.sut.functionDeclarations.first?.returnType) == .tuple([.simple(name: "Int"), .simple(name: "Int")])
+        }
+
+      }
+
+      context("multiple functions") {
+        beforeEach {
+          let content = """
+            func minMax(array: [Int]) -> (min: Int, max: Int) {
+                var currentMin = array[0]
+                var currentMax = array[0]
+                for value in array[1..<array.count] {
+                    if value < currentMin {
+                        currentMin = value
+                    } else if value > currentMax {
+                        currentMax = value
+                    }
+                }
+                return (currentMin, currentMax)
+            }
+
+            func printWithoutCounting(string: String) {
+                let _ = printAndCount(string: string)
+            }
+            """
+
+          try? self.sut.walkContent(content)
+        }
+
+        it("finds the correct amount of functions") {
+          expect(self.sut.functionDeclarations.count) == 2
+        }
+        it("finds the first function") {
+          expect(self.sut.functionDeclarations.first?.name) == "minMax"
+          expect(self.sut.functionDeclarations.first?.returnType) == .tuple([.simple(name: "Int"), .simple(name: "Int")])
+        }
+        it("finds the last function") {
+          expect(self.sut.functionDeclarations.last?.name) == "printWithoutCounting"
+          expect(self.sut.functionDeclarations.last?.returnType).to(beNil())
+        }
+      }
+      
+    }
+  }
+}

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -149,13 +149,36 @@ final class NestableTypeVisitorSpec: QuickSpec {
               expect(typealiasInfo?.initializer?.asSource) == "String"
             }
           }
+
+          context("with a function") {
+            beforeEach {
+              let content = """
+                public class SomeClass {
+                  func myString() -> String {
+                    ""
+                  }
+                }
+                """
+
+              try? self.sut.walkContent(content)
+            }
+
+            it("finds the function") {
+              let info = self.sut.classes.first?.functionDeclarations.first
+              expect(info?.name) == "myString"
+            }
+          }
         }
 
         context("that is a struct") {
           context("with no conformance") {
             beforeEach {
               let content = """
-                public struct SomeStruct {}
+                public struct SomeStruct {
+                  func myString() -> String {
+                    ""
+                  }
+                }
                 """
 
               try? self.sut.walkContent(content)
@@ -174,6 +197,11 @@ final class NestableTypeVisitorSpec: QuickSpec {
 
             it("does not find an enum") {
               expect(self.sut.enums.count) == 0
+            }
+
+            it("finds the function") {
+              let info = self.sut.structs.first?.functionDeclarations.first
+              expect(info?.name) == "myString"
             }
           }
 
@@ -262,7 +290,11 @@ final class NestableTypeVisitorSpec: QuickSpec {
           context("with no conformance") {
             beforeEach {
               let content = """
-              public enum SomeEnum {}
+              public enum SomeEnum {
+                func myString() -> String {
+                  ""
+                }
+              }
               """
 
               try? self.sut.walkContent(content)
@@ -281,6 +313,11 @@ final class NestableTypeVisitorSpec: QuickSpec {
 
             it("does not find a struct") {
               expect(self.sut.structs.count) == 0
+            }
+
+            it("finds the function") {
+              let info = self.sut.enums.first?.functionDeclarations.first
+              expect(info?.name) == "myString"
             }
           }
 

--- a/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/ProtocolVisitorSpec.swift
@@ -213,6 +213,21 @@ final class ProtocolVisitorSpec: QuickSpec {
               expect(protocolInfo?.properties.last?.name) == "bar"
             }
           }
+
+          context("with a function") {
+            it("finds the function") {
+              let content = """
+                public protocol SomeProtocol {
+                 func some() -> Int
+                }
+                """
+
+              try self.sut.walkContent(content)
+
+              let protocolInfo = self.sut.protocolInfo
+              expect(protocolInfo?.functionDeclarations.first?.name) == "some"
+            }
+          }
         }
 
         context("visiting a code block with multiple top-level declarations") {


### PR DESCRIPTION
**This PR is easier to review commit-by-commit**

This PR adds information about a function name and its return type to:
- Free functions in a file
- Extensions
- Protocols
- Enums
- Classes
- Structs

We should likely add information about the argument labels and parameters, but we can do that in another PR.