### PR TITLE
Walk less of the syntax tree, and tighten up our contract for Properties and Functions visitors

### DIFF
--- a/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/ExtensionVisitor.swift
@@ -60,19 +60,13 @@ public final class ExtensionVisitor: SyntaxVisitor {
       declarationModifierVisitor.walk(modifiers)
     }
 
-    let propertyVisitor = PropertyVisitor()
-    propertyVisitor.walk(node.members)
-
-    let functionDeclarationVisitor = FunctionDeclarationVisitor()
-    functionDeclarationVisitor.walk(node)
-
     extensionInfo = ExtensionInfo(
       typeDescription: node.extendedType.typeDescription,
       inheritsFromTypes: typeInheritanceVisitor.inheritsFromTypes,
       genericRequirements: genericRequirementVisitor.genericRequirements,
       modifiers: .init(declarationModifierVisitor.modifiers),
-      properties: propertyVisitor.properties,
-      functionDeclarations: functionDeclarationVisitor.functionDeclarations)
+      properties: [],
+      functionDeclarations: [])
     return .visitChildren
   }
 
@@ -108,6 +102,26 @@ public final class ExtensionVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
+  public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+    let propertyVisitor = PropertyVisitor()
+    propertyVisitor.walk(node)
+
+    extensionInfo?.properties.append(contentsOf: propertyVisitor.properties)
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    let functionDeclarationVisitor = FunctionDeclarationVisitor()
+    functionDeclarationVisitor.walk(node)
+
+    extensionInfo?.functionDeclarations.append(contentsOf: functionDeclarationVisitor.functionDeclarations)
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
   // MARK: Private
 
   private func visitNestableDeclaration<DeclSyntax: NestableDeclSyntax>(node: DeclSyntax) -> SyntaxVisitorContinueKind {
@@ -133,9 +147,9 @@ public final class ExtensionVisitor: SyntaxVisitor {
 
 public struct ExtensionInfo: Codable, Hashable {
   public let typeDescription: TypeDescription
-  public private(set) var inheritsFromTypes: [TypeDescription]
-  public private(set) var genericRequirements: [GenericRequirement]
+  public let inheritsFromTypes: [TypeDescription]
+  public let genericRequirements: [GenericRequirement]
   public let modifiers: Set<String>
-  public let properties: [PropertyInfo]
-  public let functionDeclarations: [FunctionDeclarationInfo]
+  public fileprivate(set) var properties: [PropertyInfo]
+  public fileprivate(set) var functionDeclarations: [FunctionDeclarationInfo]
 }

--- a/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
@@ -13,6 +13,31 @@ public final class FunctionDeclarationVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
+  public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+    assertionFailureOrPostNotification("Encountered a class declaration. This is a usage error: a single FunctionDeclarationVisitor instance should start walking only over a function declaration node")
+    return .skipChildren
+  }
+
+  public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+    assertionFailureOrPostNotification("Encountered a struct declaration. This is a usage error: a single FunctionDeclarationVisitor instance should start walking only over a function declaration node")
+    return .skipChildren
+  }
+
+  public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+    assertionFailureOrPostNotification("Encountered an enum declaration. This is a usage error: a single FunctionDeclarationVisitor instance should start walking only over a function declaration node")
+    return .skipChildren
+  }
+
+  public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
+    assertionFailureOrPostNotification("Encountered a protocol declaration. This is a usage error: a single FunctionDeclarationVisitor instance should start walking only over a function declaration node")
+    return .skipChildren
+  }
+
+  public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+    assertionFailureOrPostNotification("Encountered an extension declaration. This is a usage error: a single FunctionDeclarationVisitor instance should start walking only over a function declaration node")
+    return .skipChildren
+  }
+
   public var functionDeclarations: [FunctionDeclarationInfo] = []
 }
 

--- a/Sources/SwiftInspectorVisitors/NestableTypeInfo.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeInfo.swift
@@ -29,8 +29,8 @@ public struct NestableTypeInfo: Codable, Hashable {
   public let modifiers: Set<String>
   public let genericParameters: [GenericParameter]
   public let genericRequirements: [GenericRequirement]
-  public let properties: [PropertyInfo]
-  public let functionDeclarations: [FunctionDeclarationInfo]
+  public internal(set) var properties: [PropertyInfo]
+  public internal(set) var functionDeclarations: [FunctionDeclarationInfo]
 }
 
 public typealias ClassInfo = NestableTypeInfo

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -106,6 +106,38 @@ public final class NestableTypeVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
+  public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard let topLevelDeclaration = topLevelDeclaration else {
+      // We don't have anything to update, so skip it.
+      return .skipChildren
+    }
+
+    let visitor = PropertyVisitor()
+    visitor.walk(node)
+
+    self.topLevelDeclaration = topLevelDeclaration
+      .withAdditionalProperties(visitor.properties)
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
+  public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+    guard let topLevelDeclaration = topLevelDeclaration else {
+      // We don't have anything to update, so skip it.
+      return .skipChildren
+    }
+
+    let visitor = FunctionDeclarationVisitor()
+    visitor.walk(node)
+
+    self.topLevelDeclaration = topLevelDeclaration
+      .withAdditionalFunctions(visitor.functionDeclarations)
+
+    // We don't need to visit children because our visitor just did that for us.
+    return .skipChildren
+  }
+
   // MARK: Private
 
   private func visitNestableDeclaration<DeclSyntax: NestableDeclSyntax>(
@@ -159,13 +191,6 @@ public final class NestableTypeVisitor: SyntaxVisitor {
         genericRequirementVisitor.walk(genericWhereClause)
       }
 
-      let visitor = FunctionDeclarationVisitor()
-      visitor.walk(node)
-      let functionDeclarations = visitor.functionDeclarations
-
-      let propertyVisitor = PropertyVisitor()
-      propertyVisitor.walk(node.members)
-
       topLevelDeclaration = topLevelDeclarationCreator(
         .init(
           name: node.identifier.text,
@@ -174,8 +199,8 @@ public final class NestableTypeVisitor: SyntaxVisitor {
           modifiers: Set(declarationModifierVisitor.modifiers),
           genericParameters: genericParameterVisitor.genericParameters,
           genericRequirements: genericRequirementVisitor.genericRequirements,
-          properties: propertyVisitor.properties,
-          functionDeclarations: functionDeclarations))
+          properties: [],
+          functionDeclarations: []))
 
       return .visitChildren
     }
@@ -235,6 +260,31 @@ private enum TopLevelDeclaration {
     case .topLevelClass,
          .topLevelStruct:
       return nil
+    }
+  }
+
+  func withAdditionalProperties(_ properties: [PropertyInfo]) -> Self {
+    var nestableInfo = self.nestableInfo
+    nestableInfo.properties += properties
+    return topLevelDeclarationCreator(nestableInfo)
+  }
+
+  func withAdditionalFunctions(_ functions: [FunctionDeclarationInfo]) -> Self {
+    var nestableInfo = self.nestableInfo
+    nestableInfo.functionDeclarations += functions
+    return topLevelDeclarationCreator(nestableInfo)
+  }
+
+  // MARK: Private
+
+  private var topLevelDeclarationCreator: (NestableTypeInfo) -> TopLevelDeclaration {
+    switch self {
+    case .topLevelClass:
+      return { .topLevelClass($0) }
+    case .topLevelEnum:
+      return { .topLevelEnum($0) }
+    case .topLevelStruct:
+      return { .topLevelStruct($0) }
     }
   }
 }

--- a/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/NestableTypeVisitor.swift
@@ -108,7 +108,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
 
   public override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
     guard let topLevelDeclaration = topLevelDeclaration else {
-      // We don't have anything to update, so skip it.
+      assertionFailureOrPostNotification("Encountered a variable declaration. This is a usage error: a single NestableTypeVisitor instance should start walking only over a nestable declaration syntax node")
       return .skipChildren
     }
 
@@ -124,7 +124,7 @@ public final class NestableTypeVisitor: SyntaxVisitor {
 
   public override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
     guard let topLevelDeclaration = topLevelDeclaration else {
-      // We don't have anything to update, so skip it.
+      assertionFailureOrPostNotification("Encountered a function declaration. This is a usage error: a single NestableTypeVisitor instance should start walking only over a nestable declaration syntax node")
       return .skipChildren
     }
 

--- a/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/PropertyVisitor.swift
@@ -54,23 +54,28 @@ public final class PropertyVisitor: SyntaxVisitor {
   }
 
   public override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-    .skipChildren
+    assertionFailureOrPostNotification("Encountered a class declaration. This is a usage error: a single PropertyVisitor instance should start walking only over a property declaration node")
+    return .skipChildren
   }
 
   public override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-    .skipChildren
+    assertionFailureOrPostNotification("Encountered a struct declaration. This is a usage error: a single PropertyVisitor instance should start walking only over a property declaration node")
+    return .skipChildren
   }
 
   public override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-    .skipChildren
+    assertionFailureOrPostNotification("Encountered an enum declaration. This is a usage error: a single PropertyVisitor instance should start walking only over a property declaration node")
+    return .skipChildren
   }
 
   public override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-    .skipChildren
+    assertionFailureOrPostNotification("Encountered a protocol declaration. This is a usage error: a single PropertyVisitor instance should start walking only over a property declaration node")
+    return .skipChildren
   }
 
   public override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-    .skipChildren
+    assertionFailureOrPostNotification("Encountered an extension declaration. This is a usage error: a single PropertyVisitor instance should start walking only over a property declaration node")
+    return .skipChildren
   }
 
   // MARK: Private

--- a/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
@@ -10,6 +10,7 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
   override func spec() {
     beforeEach {
       self.sut = FunctionDeclarationVisitor()
+      AssertionFailure.postNotification = true
     }
 
     describe("visit(_:)") {
@@ -212,6 +213,82 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
           expect(self.sut.functionDeclarations.first?.selectorName) == "append(argumentLabelName:type:)"
         }
       }
+
+      context("visiting a code block with a class declaration") {
+        it("asserts") {
+          let content = """
+            final class Test {
+              func test() {}
+            }
+            """
+
+          // The FunctionDeclarationVisitor is only meant to be used over a single function declaration.
+          // Using a FunctionDeclarationVisitor over a block that has a class declaration
+          // is API misuse.
+          expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+        }
+      }
+
+      context("visiting a code block with a struct declaration") {
+        it("asserts") {
+          let content = """
+            struct Test {
+              func test() {}
+            }
+            """
+
+          // The FunctionDeclarationVisitor is only meant to be used over a single function declaration.
+          // Using a FunctionDeclarationVisitor over a block that has a struct declaration
+          // is API misuse.
+          expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+        }
+      }
+
+      context("visiting a code block with a enum declaration") {
+        it("asserts") {
+          let content = """
+            enum Test {
+              func test() {}
+            }
+            """
+
+          // The FunctionDeclarationVisitor is only meant to be used over a single function declaration.
+          // Using a FunctionDeclarationVisitor over a block that has an enum declaration
+          // is API misuse.
+          expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+        }
+      }
+
+      context("visiting a code block with a protocol declaration") {
+        it("asserts") {
+          let content = """
+            protocol Test {
+              func test()
+            }
+            """
+
+          // The FunctionDeclarationVisitor is only meant to be used over a single function declaration.
+          // Using a FunctionDeclarationVisitor over a block that has a protocol declaration
+          // is API misuse.
+          expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+        }
+      }
+
+      context("visiting a code block with an extension declaration") {
+        it("asserts") {
+          let content = """
+            extension Test {
+              func test()
+            }
+            """
+
+          // The FunctionDeclarationVisitor is only meant to be used over a single function declaration.
+          // Using a FunctionDeclarationVisitor over a block that has an extension declaration
+          // is API misuse.
+          expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+        }
+      }
+
     }
   }
 }

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -916,6 +916,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
                 }
                 public class FooFooClass {
                   let someFooFooClassProperty: Int = 2
+                  func someFooFooClassFunction() {}
                   public enum BarFooFooEnum {}
                 }
               }
@@ -929,6 +930,8 @@ final class NestableTypeVisitorSpec: QuickSpec {
             $0.name == "FooEnum"
               && $0.inheritsFromTypes.map { $0.asSource } == []
               && $0.parentType?.asSource == nil
+              && $0.properties.isEmpty
+              && $0.functionDeclarations.isEmpty
           }
           expect(matching.count) == 1
         }
@@ -1000,6 +1003,12 @@ final class NestableTypeVisitorSpec: QuickSpec {
           let fooFooClass = self.sut.classes.filter { $0.name == "FooFooClass" }
           let property = fooFooClass.first?.properties.first
           expect(property?.name) == "someFooFooClassProperty"
+        }
+
+        it("finds the function declared in FooEnum.FooFooClass") {
+          let fooFooClass = self.sut.classes.filter { $0.name == "FooFooClass" }
+          let function = fooFooClass.first?.functionDeclarations.first
+          expect(function?.name) == "someFooFooClassFunction"
         }
 
         it("does not find a property for FooEnum") {

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -1168,7 +1168,7 @@ final class NestableTypeVisitorSpec: QuickSpec {
             """
 
         // The NestableTypeVisitor is only meant to be used over a single nestable type.
-        // Using a NestableTypeVisitor over a block that has an free variable
+        // Using a NestableTypeVisitor over a block that has a free variable
         // is API misuse.
         expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
       }

--- a/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/NestableTypeVisitorSpec.swift
@@ -1152,6 +1152,32 @@ final class NestableTypeVisitorSpec: QuickSpec {
       }
     }
 
+    context("visiting a code block with a free variable declaration") {
+      it("asserts") {
+        let content = """
+            let test = 0
+            """
+
+        // The NestableTypeVisitor is only meant to be used over a single nestable type.
+        // Using a NestableTypeVisitor over a block that has an free variable
+        // is API misuse.
+        expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+      }
+    }
+
+    context("visiting a code block with a free function declaration") {
+      it("asserts") {
+        let content = """
+            func test() {}
+            """
+
+        // The NestableTypeVisitor is only meant to be used over a single nestable type.
+        // Using a NestableTypeVisitor over a block that has an free function
+        // is API misuse.
+        expect(try self.sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+      }
+    }
+
     context("visiting a code block with a protocol declaration") {
       it("asserts") {
         let content = """

--- a/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/PropertyVisitorSpec.swift
@@ -37,6 +37,7 @@ final class PropertyVisitorSpec: QuickSpec {
 
       beforeEach {
         sut = PropertyVisitor()
+        AssertionFailure.postNotification = true
       }
 
       context("when there are multiple properties on the same line") {
@@ -373,44 +374,80 @@ final class PropertyVisitorSpec: QuickSpec {
         }
       }
 
-      context("when there is a type declaration in content") {
-        let content = """
-        let hex: Int
-        final class FakeClass {
-          let timestamp: Int
-        }
-        struct FakeStruct {
-          let timestamp: Int
-        }
-        enum FakeEnum {
-          var timestamp: Int { 0 }
-        }
-        protocol FakeProtocol {
-          var timestamp: Int { get }
-        }
-        extension FakeProtocol {
-          var timestamp: Int { 0 }
-        }
-        """
+      context("visiting a code block with a class declaration") {
+        it("asserts") {
+          let content = """
+            final class Test {
+              let test = 0
+            }
+            """
 
-        it("detect properties outside the type declaration") {
-          try sut.walkContent(content)
-          let expected: [PropertyInfo] = [
-            .init(
-              name: "hex",
-              typeDescription: .simple(name: "Int"),
-              modifiers: [.internal, .instance],
-              paradigm: .undefinedConstant)
-          ]
-          expect(sut.properties).to(contain(expected))
-        }
-
-        it("does not detect properties within type declaration") {
-          try sut.walkContent(content)
-          expect(sut.properties.map(\.name)).notTo(contain("timestamp"))
+          // The PropertyVisitor is only meant to be used over a single property declaration.
+          // Using a PropertyVisitor over a block that has a class declaration
+          // is API misuse.
+          expect(try sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
         }
       }
 
+      context("visiting a code block with a struct declaration") {
+        it("asserts") {
+          let content = """
+            struct Test {
+              let test = 0
+            }
+            """
+
+          // The PropertyVisitor is only meant to be used over a single property declaration.
+          // Using a PropertyVisitor over a block that has a struct declaration
+          // is API misuse.
+          expect(try sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+        }
+      }
+
+      context("visiting a code block with a enum declaration") {
+        it("asserts") {
+          let content = """
+            enum Test {
+              var test: Int { 0 }
+            }
+            """
+
+          // The PropertyVisitor is only meant to be used over a single property declaration.
+          // Using a PropertyVisitor over a block that has an enum declaration
+          // is API misuse.
+          expect(try sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+        }
+      }
+
+      context("visiting a code block with a protocol declaration") {
+        it("asserts") {
+          let content = """
+            protocol Test {
+              var test: Int { get }
+            }
+            """
+
+          // The PropertyVisitor is only meant to be used over a single property declaration.
+          // Using a PropertyVisitor over a block that has a protocol declaration
+          // is API misuse.
+          expect(try sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+        }
+      }
+
+      context("visiting a code block with an extension declaration") {
+        it("asserts") {
+          let content = """
+            extension Test {
+              var test: Int { 0 }
+            }
+            """
+
+          // The PropertyVisitor is only meant to be used over a single property declaration.
+          // Using a PropertyVisitor over a block that has an extension declaration
+          // is API misuse.
+          expect(try sut.walkContent(content)).to(postNotifications(equal([AssertionFailure.notification])))
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Today, our `NestableTypeVisitor` and `ExtensionVisitor` both walk the entire node tree to find properties and again to find functions. This leads to a performance hit (we're doing more than we have to!), and also led to a very real bug on `main`: our `FunctionsVisitor` attributes functions found in nested classes to the parent class type.

This PR resolves these issues by creating the `PropertyVisitor` and `FunctionVisitor` just-in-time when we encounter the expected declaration. It also tightens up the contract to make running both `PropertyVisitor` and `FunctionVisitor` over unexpected type declarations a contract violation.