### PR TITLE
Disable code coverage on patch

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,7 @@ coverage:
     project:
       default:
         threshold: 0.25%
+    patch: off
 ignore:
   - "Sources/SwiftInspectorAnalyzers/Tests"
   - "Sources/SwiftInspectorCommands/Tests"


### PR DESCRIPTION
On a [previous PR](https://github.com/fdiaz/SwiftInspector/pull/126) we removed the [patch status](https://docs.codecov.com/docs/commit-status#patch-status) from enforcement, but we're still running it.

This PR disables patch completely since we're not gonna use it.