### PR TITLE
Update dependencies and binary to support releasing with Swift 5.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ xcode_toolchain ?= $(xcode_path)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swi
 
 .PHONY: build
 build:
-	swift build -c release --arch arm64 --arch x86_64
+	xcrun swift build -c release --arch arm64 --arch x86_64
 
 .PHONY: install
 install: build 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ xcode_toolchain ?= $(xcode_path)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swi
 
 .PHONY: build
 build:
-	swift build -c release
+	swift build -c release --arch arm64 --arch x86_64
 
 .PHONY: install
 install: build 
@@ -19,13 +19,8 @@ uninstall:
 clean:
 	rm -rf .build
 
-# Following https://www.smileykeith.com/2021/03/03/editing-rpaths/
 .PHONY: release
 release: build
-	mkdir -p bin lib
-	cp .build/release/swiftinspector bin
-	cp "$(xcode_toolchain)/lib_InternalSwiftSyntaxParser.dylib" "lib"
-	install_name_tool -delete_rpath @loader_path -delete_rpath $(xcode_toolchain) bin/swiftinspector
-	install_name_tool -add_rpath @executable_path/../lib bin/swiftinspector
-	zip swiftinspector.zip -r bin lib
-	rm -r bin lib
+	cp .build/apple/Products/Release/swiftinspector .
+	zip "swiftinspector-$(shell git rev-parse --short HEAD).zip" swiftinspector
+	rm swiftinspector

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,9 @@ let package = Package(
       name: "SwiftInspector",
       dependencies: [
         "SwiftInspectorCommands",
+        "lib_InternalSwiftSyntaxParser",
       ],
-      linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "$DT_TOOLCHAIN_DIR/usr/lib/swift/macosx"])]),
+      linkerSettings: [.unsafeFlags(["-Xlinker", "-dead_strip_dylibs"])]),
 
     .target(
       name: "SwiftInspectorCommands",
@@ -98,5 +99,11 @@ let package = Package(
       ],
       path: "Sources/SwiftInspectorVisitors/Tests",
       linkerSettings: [.unsafeFlags(["-Xlinker", "-rpath", "-Xlinker", "$DT_TOOLCHAIN_DIR/usr/lib/swift/macosx"])]),
+
+      .binaryTarget(
+          name: "lib_InternalSwiftSyntaxParser",
+          url: "https://github.com/keith/StaticInternalSwiftSyntaxParser/releases/download/5.6/lib_InternalSwiftSyntaxParser.xcframework.zip",
+          checksum: "88d748f76ec45880a8250438bd68e5d6ba716c8042f520998a438db87083ae9d"
+      ),
   ]
 )


### PR DESCRIPTION
As title. Also got our script capable of releasing from an M1 Mac. This change was inspired by work done by @fdiaz elsewhere.

I tested this by running unit tests in the Package.swift project, and by running `make release` and executing that binary. I did all of this on an Intel Mac.

cc @qyang-nj