### PR TITLE
Add Swift Package Index documentation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,6 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets:
+      - SwiftInspectorAnalyzers
+      - SwiftInspectorVisitors


### PR DESCRIPTION
Adds support for generating documentation following https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/