### PR TITLE
Add support for parameter names

### DIFF
--- a/Sources/SwiftInspectorAnalyzers/InitializerAnalyzer.swift
+++ b/Sources/SwiftInspectorAnalyzers/InitializerAnalyzer.swift
@@ -83,7 +83,7 @@ public final class InitializerAnalyzer: Analyzer {
 
   private func findParameter(from node: FunctionParameterSyntax) -> InitializerStatement.Parameter {
     let name: String
-    // If the initializer contains a different parameter and an argument label we want to check first
+    // If the initializer contains a different parameter name and an argument label we want to check first
     // for the parameter. e.g. init(some another: String) -- the parameter would be `another`
     if let secondName = node.secondName {
       name = secondName.text

--- a/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
@@ -15,7 +15,7 @@ public final class FunctionDeclarationVisitor: SyntaxVisitor {
     let info = FunctionDeclarationInfo(
       modifiers: modifiersVisitor.modifiers,
       name: name,
-      arguments: functionSignatureVisitor.arguments,
+      parameters: functionSignatureVisitor.parameters,
       returnType: functionSignatureVisitor.returnType)
     functionDeclarations.append(info)
     return .skipChildren
@@ -52,13 +52,13 @@ public final class FunctionDeclarationVisitor: SyntaxVisitor {
 fileprivate final class FunctionSignatureVisitor: SyntaxVisitor {
   override func visit(_ node: FunctionParameterSyntax) -> SyntaxVisitorContinueKind {
     guard
-      let argumentLabelName = node.firstName?.text,
+      let firstMember = node.firstName?.text,
       let type = node.type?.typeDescription
     else { return .skipChildren }
 
-    let parameterName = node.secondName?.text
+    let secondMember = node.secondName?.text
 
-    appendArgument(argumentLabelName: argumentLabelName, parameterName: parameterName, type: type)
+    appendParameter(firstMember: firstMember, secondMember: secondMember, type: type)
     return .skipChildren
   }
   override func visit(_ node: ReturnClauseSyntax) -> SyntaxVisitorContinueKind {
@@ -66,30 +66,33 @@ fileprivate final class FunctionSignatureVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
-  fileprivate func appendArgument(argumentLabelName: String, parameterName: String?, type: TypeDescription) {
-    var arguments = self.arguments ?? []
-    // By default, parameters use their parameter name as their argument label
-    let param = parameterName ?? argumentLabelName
-    arguments.append(.init(argumentLabelName: argumentLabelName, parameterName: param, type: type))
-    self.arguments = arguments
+  fileprivate func appendParameter(firstMember: String, secondMember: String?, type: TypeDescription) {
+    var parameters = self.parameters ?? []
+    // Each function parameter has both an argument label and a parameter name.
+    // The argument label is used when calling the function; each argument is written in the function call with its argument label before it.
+    // The parameter name is used in the implementation of the function. By default, parameters use their parameter name as their argument label.
+    let argumentLabel = firstMember
+    let parameterName = secondMember ?? firstMember
+    parameters.append(.init(argumentLabelName: argumentLabel, parameterName: parameterName, type: type))
+    self.parameters = parameters
   }
 
-  fileprivate var arguments: [FunctionDeclarationInfo.ArgumentInfo]?
+  fileprivate var parameters: [FunctionDeclarationInfo.ParameterInfo]?
   fileprivate var returnType: TypeDescription?
 }
 
 public struct FunctionDeclarationInfo: Codable, Hashable {
   public let modifiers: Modifiers
   public let name: String
-  public let arguments: [ArgumentInfo]?
+  public let parameters: [ParameterInfo]?
   public let returnType: TypeDescription?
 
   /// A convenience for creating a selector string that can be reference in Objective-C code.
   public var selectorName: String {
-    "\(name)(\((arguments ?? []).map { "\($0.argumentLabelName):" }.joined()))"
+    "\(name)(\((parameters ?? []).map { "\($0.argumentLabelName):" }.joined()))"
   }
 
-  public struct ArgumentInfo: Codable, Hashable {
+  public struct ParameterInfo: Codable, Hashable {
     public let argumentLabelName: String
     public let parameterName: String
     public let type: TypeDescription

--- a/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
+++ b/Sources/SwiftInspectorVisitors/FunctionDeclarationVisitor.swift
@@ -56,7 +56,9 @@ fileprivate final class FunctionSignatureVisitor: SyntaxVisitor {
       let type = node.type?.typeDescription
     else { return .skipChildren }
 
-    appendArgument(argumentLabelName: argumentLabelName, type: type)
+    let parameterName = node.secondName?.text
+
+    appendArgument(argumentLabelName: argumentLabelName, parameterName: parameterName, type: type)
     return .skipChildren
   }
   override func visit(_ node: ReturnClauseSyntax) -> SyntaxVisitorContinueKind {
@@ -64,9 +66,11 @@ fileprivate final class FunctionSignatureVisitor: SyntaxVisitor {
     return .skipChildren
   }
 
-  fileprivate func appendArgument(argumentLabelName: String, type: TypeDescription) {
+  fileprivate func appendArgument(argumentLabelName: String, parameterName: String?, type: TypeDescription) {
     var arguments = self.arguments ?? []
-    arguments.append(.init(argumentLabelName: argumentLabelName, type: type))
+    // By default, parameters use their parameter name as their argument label
+    let param = parameterName ?? argumentLabelName
+    arguments.append(.init(argumentLabelName: argumentLabelName, parameterName: param, type: type))
     self.arguments = arguments
   }
 
@@ -87,6 +91,7 @@ public struct FunctionDeclarationInfo: Codable, Hashable {
 
   public struct ArgumentInfo: Codable, Hashable {
     public let argumentLabelName: String
+    public let parameterName: String
     public let type: TypeDescription
   }
 }

--- a/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
@@ -33,8 +33,9 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
           expect(self.sut.functionDeclarations.first?.name) == "greet"
         }
         it("finds the function parameter") {
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.argumentLabelName) == "person"
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.type) == .simple(name: "String")
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.argumentLabelName) == "person"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.parameterName) == "person"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.type) == .simple(name: "String")
         }
         it("finds the return type") {
           expect(self.sut.functionDeclarations.first?.returnType) == TypeDescription.simple(name: "String")
@@ -59,8 +60,9 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
           expect(self.sut.functionDeclarations.first?.name) == "printWithoutCounting"
         }
         it("finds the function parameter") {
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.argumentLabelName) == "string"
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.type) == .simple(name: "String")
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.argumentLabelName) == "string"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.parameterName) == "string"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.type) == .simple(name: "String")
         }
         it("sets the return type as nil") {
           expect(self.sut.functionDeclarations.first?.returnType).to(beNil())
@@ -94,8 +96,9 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
           expect(self.sut.functionDeclarations.first?.name) == "minMax"
         }
         it("finds the function parameter") {
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.argumentLabelName) == "array"
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.type) == .array(element: .simple(name: "Int"))
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.argumentLabelName) == "array"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.parameterName) == "array"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.type) == .array(element: .simple(name: "Int"))
         }
         it("finds the tuple return value") {
           expect(self.sut.functionDeclarations.first?.returnType) == .tuple([.simple(name: "Int"), .simple(name: "Int")])
@@ -134,16 +137,16 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
           let firstFunction = self.sut.functionDeclarations.first
           expect(firstFunction?.modifiers) == Modifiers.public
           expect(firstFunction?.name) == "minMax"
-          expect(firstFunction?.arguments?.first?.argumentLabelName) == "array"
-          expect(firstFunction?.arguments?.first?.type) == .array(element: .simple(name: "Int"))
+          expect(firstFunction?.parameters?.first?.argumentLabelName) == "array"
+          expect(firstFunction?.parameters?.first?.type) == .array(element: .simple(name: "Int"))
           expect(firstFunction?.returnType) == .tuple([.simple(name: "Int"), .simple(name: "Int")])
         }
         it("finds the last function") {
           let lastFunction = self.sut.functionDeclarations.last
           expect(lastFunction?.modifiers) == [.private, .static]
           expect(lastFunction?.name) == "printWithoutCounting"
-          expect(lastFunction?.arguments?.first?.argumentLabelName) == "string"
-          expect(lastFunction?.arguments?.first?.type) == .simple(name: "String")
+          expect(lastFunction?.parameters?.first?.argumentLabelName) == "string"
+          expect(lastFunction?.parameters?.first?.type) == .simple(name: "String")
           expect(lastFunction?.returnType).to(beNil())
         }
       }
@@ -159,12 +162,12 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
           try? self.sut.walkContent(content)
         }
 
-        it("finds no arguments") {
-          expect(self.sut.functionDeclarations.first?.arguments).to(beNil())
+        it("finds no parameters") {
+          expect(self.sut.functionDeclarations.first?.parameters).to(beNil())
         }
       }
 
-      context("function with no argument label") {
+      context("function with empty argument label") {
         beforeEach {
           let content = """
             func print(_ string: String) {
@@ -176,10 +179,10 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
         }
 
         it("finds the argument label") {
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.argumentLabelName) == "_"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.argumentLabelName) == "_"
         }
         it("finds the parameter name") {
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.parameterName) == "string"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.parameterName) == "string"
         }
         it("calculates the selectorName") {
           expect(self.sut.functionDeclarations.first?.selectorName) == "print(_:)"
@@ -197,14 +200,14 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
           try? self.sut.walkContent(content)
         }
 
-        it("finds the parameter label") {
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.argumentLabelName) == "argumentLabelName"
+        it("finds the argument label") {
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.argumentLabelName) == "argumentLabelName"
         }
         it("calculates the selectorName") {
           expect(self.sut.functionDeclarations.first?.selectorName) == "append(argumentLabelName:)"
         }
         it("finds the parameter name") {
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.parameterName) == "parameterName"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.parameterName) == "parameterName"
         }
       }
 
@@ -220,15 +223,15 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
         }
 
         it("finds the correct number of parameters") {
-          expect(self.sut.functionDeclarations.first?.arguments?.count) == 2
+          expect(self.sut.functionDeclarations.first?.parameters?.count) == 2
         }
         it("finds the argument labels") {
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.argumentLabelName) == "argumentLabelName"
-          expect(self.sut.functionDeclarations.first?.arguments?.last?.argumentLabelName) == "type"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.argumentLabelName) == "argumentLabelName"
+          expect(self.sut.functionDeclarations.first?.parameters?.last?.argumentLabelName) == "type"
         }
         it("finds the parameter names") {
-          expect(self.sut.functionDeclarations.first?.arguments?.first?.parameterName) == "parameterName"
-          expect(self.sut.functionDeclarations.first?.arguments?.last?.parameterName) == "secondParameterName"
+          expect(self.sut.functionDeclarations.first?.parameters?.first?.parameterName) == "parameterName"
+          expect(self.sut.functionDeclarations.first?.parameters?.last?.parameterName) == "secondParameterName"
         }
         it("calculates the selectorName") {
           expect(self.sut.functionDeclarations.first?.selectorName) == "append(argumentLabelName:type:)"

--- a/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
+++ b/Sources/SwiftInspectorVisitors/Tests/FunctionDeclarationVisitorSpec.swift
@@ -175,8 +175,11 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
           try? self.sut.walkContent(content)
         }
 
-        it("finds the parameter label") {
+        it("finds the argument label") {
           expect(self.sut.functionDeclarations.first?.arguments?.first?.argumentLabelName) == "_"
+        }
+        it("finds the parameter name") {
+          expect(self.sut.functionDeclarations.first?.arguments?.first?.parameterName) == "string"
         }
         it("calculates the selectorName") {
           expect(self.sut.functionDeclarations.first?.selectorName) == "print(_:)"
@@ -200,12 +203,15 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
         it("calculates the selectorName") {
           expect(self.sut.functionDeclarations.first?.selectorName) == "append(argumentLabelName:)"
         }
+        it("finds the parameter name") {
+          expect(self.sut.functionDeclarations.first?.arguments?.first?.parameterName) == "parameterName"
+        }
       }
 
       context("function with multiple parameters") {
         beforeEach {
           let content = """
-            func append(argumentLabelName parameterName: String, type: TypeDescription) {
+            func append(argumentLabelName parameterName: String, type secondParameterName: TypeDescription) {
               // ...
             }
             """
@@ -216,9 +222,13 @@ final class FunctionDeclarationVisitorSpec: QuickSpec {
         it("finds the correct number of parameters") {
           expect(self.sut.functionDeclarations.first?.arguments?.count) == 2
         }
-        it("finds the parameter labels") {
+        it("finds the argument labels") {
           expect(self.sut.functionDeclarations.first?.arguments?.first?.argumentLabelName) == "argumentLabelName"
           expect(self.sut.functionDeclarations.first?.arguments?.last?.argumentLabelName) == "type"
+        }
+        it("finds the parameter names") {
+          expect(self.sut.functionDeclarations.first?.arguments?.first?.parameterName) == "parameterName"
+          expect(self.sut.functionDeclarations.first?.arguments?.last?.parameterName) == "secondParameterName"
         }
         it("calculates the selectorName") {
           expect(self.sut.functionDeclarations.first?.selectorName) == "append(argumentLabelName:type:)"


### PR DESCRIPTION
This PR adds support for parameter names in functions.

We were already supporting argument labels so adding this was fairly trivial.